### PR TITLE
Added support for Doctrine Embedabbles

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,9 +563,9 @@ Once again, two cases may arise: the tags already exist or they do not.
 
 ##### Example 4: Embedded Entities
 
-Doctrine provides so-called embeddables as a layer of abstraction which allow reusing partial object accross entities. 
+Doctrine provides so-called embeddables as a layer of abstraction which allow reusing partial object across entities. 
 For example, one might have an entity `Address` which is not only used for a `Person`, but probably for an `Organisation`
-as well. Let's have a look at the entities:
+as well. Let's have a look at the classes. First we have a `Tag` class, which will be our embeddable:
 
 ```php
 namespace Application\Entity;
@@ -611,7 +611,7 @@ class Tag
 }
 ```
 
-And a corresponding `Person` entity, where the above embeddable is used:
+Then we have a corresponding `Person` entity, where the above embeddable is used:
 
 ```php
 <?php

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -114,6 +114,7 @@ class DoctrineObject extends AbstractHydrator
     /**
      * Get all field names, this includes direct field names, names of embeddables and
      * associations. By using a key-based generator, duplicates are effectively removed.
+     * @return list<string>
      */
     public function getFieldNames(): iterable
     {

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -114,6 +114,7 @@ class DoctrineObject extends AbstractHydrator
     /**
      * Get all field names, this includes direct field names, names of embeddables and
      * associations. By using a key-based generator, duplicates are effectively removed.
+     *
      * @return list<string>
      */
     public function getFieldNames(): iterable
@@ -123,7 +124,7 @@ class DoctrineObject extends AbstractHydrator
             if ($pos = strpos($fieldName, '.')) {
                 $fieldName = substr($fieldName, 0, $pos);
             }
-            yield $fieldName => $fieldName;
+            yield $fieldName;
         }
     }
 
@@ -218,14 +219,13 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function extractByValue($object)
     {
-        $fieldNames = $this->getFieldNames();
-        $methods    = get_class_methods($object);
-        $filter     = $object instanceof FilterProviderInterface
+        $methods = get_class_methods($object);
+        $filter  = $object instanceof FilterProviderInterface
             ? $object->getFilter()
             : $this->filterComposite;
 
         $data = [];
-        foreach ($fieldNames as $fieldName) {
+        foreach ($this->getFieldNames() as $fieldName) {
             if ($filter && ! $filter->filter($fieldName)) {
                 continue;
             }
@@ -261,14 +261,13 @@ class DoctrineObject extends AbstractHydrator
      */
     protected function extractByReference($object)
     {
-        $fieldNames = $this->getFieldNames();
-        $refl       = $this->metadata->getReflectionClass();
-        $filter     = $object instanceof FilterProviderInterface
+        $refl   = $this->metadata->getReflectionClass();
+        $filter = $object instanceof FilterProviderInterface
             ? $object->getFilter()
             : $this->filterComposite;
 
         $data = [];
-        foreach ($fieldNames as $fieldName) {
+        foreach ($this->getFieldNames() as $fieldName) {
             if ($filter && ! $filter->filter($fieldName)) {
                 continue;
             }

--- a/test/Assets/EmbedabbleEntity.php
+++ b/test/Assets/EmbedabbleEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineTest\Laminas\Hydrator\Assets;
+
+class EmbedabbleEntity
+{
+    /** @var string */
+    protected $field;
+
+    public function setField(string $field)
+    {
+        $this->field = $field;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+}

--- a/test/Assets/SimpleEntityWithEmbeddable.php
+++ b/test/Assets/SimpleEntityWithEmbeddable.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineTest\Laminas\Hydrator\Assets;
+
+class SimpleEntityWithEmbeddable
+{
+    /** @var int */
+    protected $id;
+
+    /** @var EmbedabbleEntity */
+    protected $embedded;
+
+    public function __construct()
+    {
+        $this->embedded = new EmbedabbleEntity();
+    }
+
+    public function setId(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setEmbedded(EmbedabbleEntity $embedded)
+    {
+        $this->embedded = $embedded;
+    }
+
+    public function getEmbedded(): EmbedabbleEntity
+    {
+        return $this->embedded;
+    }
+}

--- a/test/DoctrineObjectTest.php
+++ b/test/DoctrineObjectTest.php
@@ -483,19 +483,16 @@ class DoctrineObjectTest extends TestCase
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('hasAssociation')
             ->will($this->returnValue(false));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getIdentifierFieldNames')
             ->will($this->returnValue(['id']));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getReflectionClass')
             ->will($this->returnValue($refl));
 

--- a/test/DoctrineObjectTest.php
+++ b/test/DoctrineObjectTest.php
@@ -440,6 +440,75 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
+    public function configureObjectManagerForSimpleEntityWithEmbeddable()
+    {
+        $refl = new ReflectionClass(Assets\SimpleEntityWithEmbeddable::class);
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getAssociationNames')
+            ->will($this->returnValue([]));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getFieldNames')
+            ->will($this->returnValue(['id', 'embedded.field']));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getTypeOfField')
+            ->with($this->logicalOr(
+                $this->equalTo('id'),
+                $this->equalTo('embedded.field'),
+                $this->equalTo('embedded')
+            ))
+            ->will(
+                $this->returnCallback(
+                    function ($arg) {
+                        if ($arg === 'id') {
+                            return 'integer';
+                        } elseif ($arg === 'embedded.field') {
+                            return 'string';
+                        } elseif ($arg === 'embedded') {
+                            return null;
+                        }
+
+                        throw new InvalidArgumentException();
+                    }
+                )
+            );
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('hasAssociation')
+            ->will($this->returnValue(false));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getIdentifierFieldNames')
+            ->will($this->returnValue(['id']));
+
+        $this
+            ->metadata
+            ->expects($this->any())
+            ->method('getReflectionClass')
+            ->will($this->returnValue($refl));
+
+        $this->hydratorByValue     = new DoctrineObjectHydrator(
+            $this->objectManager,
+            true
+        );
+        $this->hydratorByReference = new DoctrineObjectHydrator(
+            $this->objectManager,
+            false
+        );
+    }
+
     public function configureObjectManagerForOneToOneEntity()
     {
         $refl = new ReflectionClass(Assets\OneToOneEntity::class);
@@ -1022,6 +1091,64 @@ class DoctrineObjectTest extends TestCase
 
         $this->assertInstanceOf(Assets\ByValueDifferentiatorEntity::class, $entity);
         $this->assertEquals('bar', $entity->getField(false));
+    }
+
+    public function testCanExtractSimpleEntityWithEmbeddableByValue()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $entity = new Assets\SimpleEntityWithEmbeddable();
+        $entity->setId(2);
+        $entity->getEmbedded()->setField('foo');
+
+        $this->configureObjectManagerForSimpleEntityWithEmbeddable();
+
+        $data = $this->hydratorByValue->extract($entity);
+        $this->assertEquals(['id' => 2, 'embedded' => $entity->getEmbedded()], $data);
+    }
+
+    public function testCanExtractSimpleEntityWithEmbeddableByReference()
+    {
+        // When using extraction by reference, it won't use the public API of entity (getters won't be called)
+        $entity = new Assets\SimpleEntityWithEmbeddable();
+        $entity->setId(2);
+        $entity->getEmbedded()->setField('foo');
+
+        $this->configureObjectManagerForSimpleEntityWithEmbeddable();
+
+        $data = $this->hydratorByReference->extract($entity);
+        $this->assertEquals(['id' => 2, 'embedded' => $entity->getEmbedded()], $data);
+    }
+
+    public function testCanHydrateSimpleEntityWithEmbeddableByValue()
+    {
+        // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
+        $entity = new Assets\SimpleEntityWithEmbeddable();
+
+        $embedded = new Assets\EmbedabbleEntity();
+        $embedded->setField('foo');
+        $data = ['embedded' => $embedded];
+
+        $this->configureObjectManagerForSimpleEntityWithEmbeddable();
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+        $this->assertInstanceOf(Assets\SimpleEntityWithEmbeddable::class, $entity);
+        $this->assertSame($entity->getEmbedded(), $embedded);
+    }
+
+    public function testCanHydrateSimpleEntityWithEmbeddableByReference()
+    {
+        // When using extraction by reference, it won't use the public API of entity (getters won't be called)
+        $entity = new Assets\SimpleEntityWithEmbeddable();
+
+        $embedded = new Assets\EmbedabbleEntity();
+        $embedded->setField('foo');
+        $data = ['embedded' => $embedded];
+
+        $this->configureObjectManagerForSimpleEntityWithEmbeddable();
+
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+        $this->assertInstanceOf(Assets\SimpleEntityWithEmbeddable::class, $entity);
+        $this->assertSame($entity->getEmbedded(), $embedded);
     }
 
     public function testExtractOneToOneAssociationByValue()

--- a/test/DoctrineObjectTest.php
+++ b/test/DoctrineObjectTest.php
@@ -446,19 +446,16 @@ class DoctrineObjectTest extends TestCase
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getAssociationNames')
             ->will($this->returnValue([]));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getFieldNames')
             ->will($this->returnValue(['id', 'embedded.field']));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getTypeOfField')
             ->with($this->logicalOr(
                 $this->equalTo('id'),
@@ -467,7 +464,7 @@ class DoctrineObjectTest extends TestCase
             ))
             ->will(
                 $this->returnCallback(
-                    function ($arg) {
+                    function (string $arg): ?string {
                         if ($arg === 'id') {
                             return 'integer';
                         } elseif ($arg === 'embedded.field') {


### PR DESCRIPTION
**Summary:** Added support for Doctrine Embedabbles

**BC Breaks:** None

**Note:** This is related to #18. However, in contrast to #18, this does neither directly extract fields from embeddables nor hydrate them. Instead, this extracts or hydrates the object from the embeddable. In consequence, this deals with embedabbles in a similar way as with a toOne relationship and requires a separat hydrator for the inner fields of the embeddable.

Using Laminas\Form this allows to create a corresponding fieldset to each embeddable and, hence, enables re-using these fieldsets accros all entities that utilize the same embeddable. See the following example of an `AddressFieldset`, which can be adopted in other fieldsets or forms:

```php
<?php

namespace Application\Form\Fieldset;

use Application\Entity\Address;
use Doctrine\Laminas\Hydrator\DoctrineObject as DoctrineHydrator;
use Doctrine\Persistence\ObjectManager;
use DoctrineModule\Persistence\ObjectManagerAwareInterface;
use DoctrineModule\Persistence\ProvidesObjectManager;
use Laminas\Filter\StringTrim;
use Laminas\Filter\ToNull;
use Laminas\Form\Element\Select;
use Laminas\Form\Fieldset;
use Laminas\InputFilter\InputFilterProviderInterface;

class AddressFieldset extends Fieldset implements ObjectManagerAwareInterface, InputFilterProviderInterface
{
    use ProvidesObjectManager;

    public function __construct(ObjectManager $objectManager)
    {
        parent::__construct('fieldset-edit-address');
        $this->setObjectManager($objectManager);
    }

    public function init()
    {
        $this->setHydrator(new DoctrineHydrator($this->getObjectManager()));
        $this->setObject(new Address());

        $this->add([
            'name' => 'street',
            'options' => [
                'label' => 'Street and Number',
            ],
        ]);

        $this->add([
            'name' => 'postCode',
            'options' => [
                'label' => 'Post Code',
            ],
        ]);

        $this->add([
            'name' => 'city',
            'options' => [
                'label' => 'City',
            ],
        ]);
    }

    public function getInputFilterSpecification()
    {
        return [
            'street' => [
                'required' => false,
                'filters' => [
                    ['name' => StringTrim::class],
                    ['name' => ToNull::class],
                ],
            ],
            'postCode' => [
                'required' => false,
                'filters' => [
                    ['name' => StringTrim::class],
                    ['name' => ToNull::class],
                ],
            ],
            'city' => [
                'required' => false,
                'filters' => [
                    ['name' => StringTrim::class],
                    ['name' => ToNull::class],
                ],
            ],
        ];
    }
}
```

Maybe this should be stated in the documentation somewhere?