### PR TITLE
type conversion fixed for decimal and bigint

### DIFF
--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -558,10 +558,12 @@ class DoctrineObject extends AbstractHydrator
                 break;
             case 'string':
             case 'text':
-            case 'bigint':
-            case 'decimal':
                 $value = (string) $value;
                 break;
+            case 'decimal':
+                $value = (float) $value;
+                break;
+            case 'bigint':
             case 'integer':
             case 'smallint':
                 $value = (int) $value;

--- a/test/DoctrineObjectTypeConversionsTest.php
+++ b/test/DoctrineObjectTypeConversionsTest.php
@@ -615,40 +615,40 @@ class DoctrineObjectTypeConversionsTest extends TestCase
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('stringvalue', $entity->getGenericField());
+        $this->assertTrue(is_int($entity->getGenericField()));
+        $this->assertEquals(0, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $data   = ['genericField' => 'stringvalue'];
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('stringvalue', $entity->getGenericField());
+        $this->assertTrue(is_int($entity->getGenericField()));
+        $this->assertEquals(0, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $data   = ['genericField' => 'stringvalue'];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('stringvalue', $entity->getGenericField());
+        $this->assertTrue(is_int($entity->getGenericField()));
+        $this->assertEquals(0, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $data   = ['genericField' => 'stringvalue'];
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('stringvalue', $entity->getGenericField());
+        $this->assertTrue(is_int($entity->getGenericField()));
+        $this->assertEquals(0, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $data   = ['genericField' => 12345];
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('12345', $entity->getGenericField());
+        $this->assertTrue(is_int($entity->getGenericField()));
+        $this->assertEquals(12345, $entity->getGenericField());
     }
 
     public function testHandleTypeConversionsDecimal()
@@ -661,40 +661,40 @@ class DoctrineObjectTypeConversionsTest extends TestCase
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('123.45', $entity->getGenericField());
+        $this->assertTrue(is_float($entity->getGenericField()));
+        $this->assertEquals(123.45, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $data   = ['genericField' => '123.45'];
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('123.45', $entity->getGenericField());
+        $this->assertTrue(is_float($entity->getGenericField()));
+        $this->assertEquals(123.45, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $data   = ['genericField' => '123.45'];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('123.45', $entity->getGenericField());
+        $this->assertTrue(is_float($entity->getGenericField()));
+        $this->assertEquals(123.45, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $data   = ['genericField' => '123.45'];
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('123.45', $entity->getGenericField());
+        $this->assertTrue(is_float($entity->getGenericField()));
+        $this->assertEquals(123.45, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $data   = ['genericField' => 12345];
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
 
-        $this->assertTrue(is_string($entity->getGenericField()));
-        $this->assertEquals('12345', $entity->getGenericField());
+        $this->assertTrue(is_float($entity->getGenericField()));
+        $this->assertEquals(12345, $entity->getGenericField());
     }
 
     public function testHandleTypeConversionsNullable()


### PR DESCRIPTION
Hello everyone,

I found a bug in the type conversion for decimal. It's casted as string instead float.
With this fix it is possible to use strict types in php 7.4

Best regards