### PR TITLE
Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,15 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class City
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", length=48)
-     */
+    #[ORM\Column(type: 'string', length: 48)]
     protected $name;
 
     public function getId()
@@ -115,21 +109,15 @@ namespace Application\Entity;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Appointment
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\Column(type="datetime")
-     */
+    #[ORM\Column(type: 'datetime')]
     protected $time;
 
     public function getId()
@@ -181,26 +169,18 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class User
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", length=48)
-     */
+    #[ORM\Column(type: 'string', length: 48)]
     protected $username;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     protected $password;
 
     public function getId()
@@ -237,26 +217,18 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class BlogPost
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="Application\Entity\User")
-     */
+    #[ORM\ManyToOne(targetEntity: 'Application\Entity\User')]
     protected $user;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     protected $title;
 
     public function getId()
@@ -365,16 +337,12 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class BlogPost
 {
     /** .. */
 
-    /**
-     * @ORM\ManyToOne(targetEntity="Application\Entity\User", cascade={"persist"})
-     */
+    #[ORM\ManyToOne(targetEntity: 'Application\Entity\User', cascade: ['persist'])] 
     protected $user;
 
     /** … */
@@ -431,21 +399,15 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class BlogPost
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\OneToMany(targetEntity="Application\Entity\Tag", mappedBy="blogPost")
-     */
+    #[ORM\OneToMany(targetEntity: 'Application\Entity\Tag', mappedBy: 'blogPost')]
     protected $tags;
 
     /**
@@ -491,26 +453,18 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Tag
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="Application\Entity\BlogPost", inversedBy="tags")
-     */
+    #[ORM\ManyToOne(targetEntity: 'Application\Entity\BlogPost', inversedBy: 'tags')]
     protected $blogPost;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     protected $name;
 
     public function getId()
@@ -574,19 +528,14 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Address class for embedding in entities.
- *
- * @ORM\Embeddable
  */
+#[ORM\Embeddable]
 class Tag
 {
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     protected ?string $postalCode = null;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     protected ?string $city = null;
 
     public function getPostalCode(): ?string
@@ -620,25 +569,17 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Person 
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue()
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
     protected ?int $id = null;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     protected ?string $name = null;
 
-    /**
-     * @ORM\Embedded(class="Address")
-     */
+    #[ORM\Embedded(class: 'Address')]
     protected Address $address;
     
     public function __construct()
@@ -780,16 +721,12 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class BlogPost
 {
     /** .. */
 
-    /**
-     * @ORM\OneToMany(targetEntity="Application\Entity\Tag", mappedBy="blogPost", cascade={"persist"})
-     */
+    #[ORM\OneToMany(targetEntity: 'Application\Entity\Tag', mappedBy: 'blogPost', cascade: ['persist'])]
     protected $tags;
 
     /** … */
@@ -877,14 +814,10 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class SimpleEntity
 {
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     protected $foo;
 
     public function getFoo()
@@ -946,21 +879,15 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class BlogPost
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\OneToMany(targetEntity="Application\Entity\Tag", mappedBy="blogPost", cascade={"persist"})
-     */
+    #[ORM\OneToMany(targetEntity: 'Application\Entity\Tag', mappedBy: 'blogPost', cascade: ['persist'])]
     protected $tags;
 
     /**
@@ -1018,26 +945,18 @@ namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Tag
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="Application\Entity\BlogPost", inversedBy="tags")
-     */
+    #[ORM\ManyToOne(targetEntity: 'Application\Entity\BlogPost', inversedBy: 'tags')]
     protected $blogPost;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     protected $name;
 
     /**
@@ -1343,27 +1262,18 @@ Imagine the following entity :
 ```php
 namespace Application\Entity;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="Students")
- */
+#[ORM\Entity]
 class User
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", length=48)
-     */
+    #[ORM\Column(type: 'string', length=48)]
     protected $name;
 
-    /**
-     * @ORM\OneToOne(targetEntity="City")
-     */
+    #[ORM\OneToOne(targetEntity: 'City')]
     protected $city;
 
     // … getter and setters are defined …

--- a/README.md
+++ b/README.md
@@ -57,22 +57,22 @@ class City
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 48)]
-    protected $name;
+    protected ?string $name = null;
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -115,22 +115,22 @@ class Appointment
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\Column(type: 'datetime')]
-    protected $time;
+    protected ?DateTime $time = null;
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setTime(DateTime $time)
+    public function setTime(DateTime $time): void
     {
         $this->time = $time;
     }
 
-    public function getTime()
+    public function getTime(): ?DateTime
     {
         return $this->time;
     }
@@ -175,35 +175,35 @@ class User
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 48)]
-    protected $username;
+    protected ?string $username = null;
 
     #[ORM\Column(type: 'string')]
-    protected $password;
+    protected ?string $password = null;
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setUsername($username)
+    public function setUsername(string $username): void
     {
         $this->username = $username;
     }
 
-    public function getUsername()
+    public function getUsername(): ?string
     {
         return $this->username;
     }
 
-    public function setPassword($password)
+    public function setPassword(string $password): void
     {
         $this->password = $password;
     }
 
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }
@@ -223,35 +223,35 @@ class BlogPost
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: 'Application\Entity\User')]
-    protected $user;
+    protected ?User $user = null;
 
     #[ORM\Column(type: 'string')]
-    protected $title;
+    protected ?string $title = null;
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setUser(User $user)
+    public function setUser(User $user): void
     {
         $this->user = $user;
     }
 
-    public function getUser()
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
-    public function setTitle($title)
+    public function setTitle(string $title): void
     {
         $this->title = $title;
     }
 
-    public function getTitle()
+    public function getTitle(): ?string
     {
         return $this->title;
     }
@@ -330,7 +330,7 @@ echo $blogPost->getUser()->getId(); // prints 2
 ```
 
 For this to work, you must also slightly change your mapping, so that Doctrine can persist new entities on
-associations (note the cascade options on the OneToMany association):
+associations (note the cascade options on the ManyToOne association):
 
 ```php
 namespace Application\Entity;
@@ -343,7 +343,7 @@ class BlogPost
     /** .. */
 
     #[ORM\ManyToOne(targetEntity: 'Application\Entity\User', cascade: ['persist'])] 
-    protected $user;
+    protected ?User $user = null;
 
     /** … */
 }
@@ -405,10 +405,10 @@ class BlogPost
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\OneToMany(targetEntity: 'Application\Entity\Tag', mappedBy: 'blogPost')]
-    protected $tags;
+    protected Collection $tags;
 
     /**
      * Never forget to initialize your collections!
@@ -418,12 +418,12 @@ class BlogPost
         $this->tags = new ArrayCollection();
     }
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function addTags(Collection $tags)
+    public function addTags(Collection $tags): void
     {
         foreach ($tags as $tag) {
             $tag->setBlogPost($this);
@@ -431,7 +431,7 @@ class BlogPost
         }
     }
 
-    public function removeTags(Collection $tags)
+    public function removeTags(Collection $tags): void
     {
         foreach ($tags as $tag) {
             $tag->setBlogPost(null);
@@ -439,7 +439,7 @@ class BlogPost
         }
     }
 
-    public function getTags()
+    public function getTags(): Collection
     {
         return $this->tags;
     }
@@ -459,15 +459,15 @@ class Tag
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: 'Application\Entity\BlogPost', inversedBy: 'tags')]
-    protected $blogPost;
+    protected ?BlogPost $blogPost = null;
 
     #[ORM\Column(type: 'string')]
-    protected $name;
+    protected ?string $name = null;
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -475,22 +475,22 @@ class Tag
     /**
      * Allow null to remove association
      */
-    public function setBlogPost(BlogPost $blogPost = null)
+    public function setBlogPost(?BlogPost $blogPost = null): void
     {
         $this->blogPost = $blogPost;
     }
 
-    public function getBlogPost()
+    public function getBlogPost(): ?BlogPost
     {
         return $this->blogPost;
     }
 
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -503,7 +503,7 @@ You may think this is overkill, and ask why you cannot just define a `setTags` f
 by the new one:
 
 ```php
-public function setTags(Collection $tags)
+public function setTags(Collection $tags): void
 {
     $this->tags = $tags;
 }
@@ -540,7 +540,7 @@ class Tag
 
     public function getPostalCode(): ?string
     {
-        return (string) $this->postalCode;
+        return $this->postalCode;
     }
 
     public function setPostalCode(?string $postalCode): void
@@ -550,7 +550,7 @@ class Tag
 
     public function getCity(): ?string
     {
-        return (string) $this->city;
+        return $this->city;
     }
     
     public function setCity(?string $city): void
@@ -582,6 +582,9 @@ class Person
     #[ORM\Embedded(class: 'Address')]
     protected Address $address;
     
+    /**
+     * Similar to collections you should initialize embeddables in the constructor!
+     */
     public function __construct()
     {
         $this->address = new Address();
@@ -592,17 +595,12 @@ class Person
         return $this->id;
     }
     
-    public function setId(?int $id)
-    {
-        $this->id = $id;
-    }
-    
     public function getName(): ?string
     {
         return $this->name;
     }
     
-    public function setName(?string $name)
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }
@@ -720,6 +718,7 @@ associations (note the cascade options on the OneToMany association):
 namespace Application\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\Collection;
 
 #[ORM\Entity]
 class BlogPost
@@ -727,7 +726,7 @@ class BlogPost
     /** .. */
 
     #[ORM\OneToMany(targetEntity: 'Application\Entity\Tag', mappedBy: 'blogPost', cascade: ['persist'])]
-    protected $tags;
+    protected Collection $tags;
 
     /** … */
 }
@@ -818,9 +817,9 @@ use Doctrine\ORM\Mapping as ORM;
 class SimpleEntity
 {
     #[ORM\Column(type: 'string')]
-    protected $foo;
+    protected ?string $foo = null;
 
-    public function getFoo()
+    public function getFoo(): void
     {
         die();
     }
@@ -885,10 +884,10 @@ class BlogPost
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\OneToMany(targetEntity: 'Application\Entity\Tag', mappedBy: 'blogPost', cascade: ['persist'])]
-    protected $tags;
+    protected Collection $tags;
 
     /**
      * Never forget to initialize your collections!
@@ -898,18 +897,12 @@ class BlogPost
         $this->tags = new ArrayCollection();
     }
 
-    /**
-     * @return integer
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param Collection $tags
-     */
-    public function addTags(Collection $tags)
+    public function addTags(Collection $tags): void
     {
         foreach ($tags as $tag) {
             $tag->setBlogPost($this);
@@ -917,10 +910,7 @@ class BlogPost
         }
     }
 
-    /**
-     * @param Collection $tags
-     */
-    public function removeTags(Collection $tags)
+    public function removeTags(Collection $tags): void
     {
         foreach ($tags as $tag) {
             $tag->setBlogPost(null);
@@ -928,10 +918,7 @@ class BlogPost
         }
     }
 
-    /**
-     * @return Collection
-     */
-    public function getTags()
+    public function getTags(): Collection
     {
         return $this->tags;
     }
@@ -951,53 +938,38 @@ class Tag
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: 'Application\Entity\BlogPost', inversedBy: 'tags')]
-    protected $blogPost;
+    protected ?BlogPost $blogPost = null;
 
     #[ORM\Column(type: 'string')]
-    protected $name;
+    protected ?string $name = null;
 
-    /**
-     * Get the id
-     * @return int
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
      * Allow null to remove association
-     *
-     * @param BlogPost $blogPost
      */
-    public function setBlogPost(BlogPost $blogPost = null)
+    public function setBlogPost(?BlogPost $blogPost = null): void
     {
         $this->blogPost = $blogPost;
     }
 
-    /**
-     * @return BlogPost
-     */
-    public function getBlogPost()
+    public function getBlogPost(): ?BlogPost
     {
         return $this->blogPost;
     }
 
-    /**
-     * @param string $name
-     */
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -1268,13 +1240,13 @@ class User
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected $id;
+    protected ?int $id = null;
 
     #[ORM\Column(type: 'string', length=48)]
-    protected $name;
+    protected ?string $name = null;
 
     #[ORM\OneToOne(targetEntity: 'City')]
-    protected $city;
+    protected ?City $city = null;
 
     // … getter and setters are defined …
 }

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ class City
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 48)]
-    protected ?string $name = null;
+    private ?string $name = null;
 
     public function getId(): ?int
     {
@@ -115,10 +115,10 @@ class Appointment
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'datetime')]
-    protected ?DateTime $time = null;
+    private ?DateTime $time = null;
 
     public function getId(): ?int
     {
@@ -175,13 +175,13 @@ class User
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 48)]
-    protected ?string $username = null;
+    private ?string $username = null;
 
     #[ORM\Column(type: 'string')]
-    protected ?string $password = null;
+    private ?string $password = null;
 
     public function getId(): ?int
     {
@@ -223,13 +223,13 @@ class BlogPost
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    protected ?User $user = null;
+    private ?User $user = null;
 
     #[ORM\Column(type: 'string')]
-    protected ?string $title = null;
+    private ?string $title = null;
 
     public function getId(): ?int
     {
@@ -343,7 +343,7 @@ class BlogPost
     /** .. */
 
     #[ORM\ManyToOne(targetEntity: User::class, cascade: ['persist'])] 
-    protected ?User $user = null;
+    private ?User $user = null;
 
     /** … */
 }
@@ -405,10 +405,10 @@ class BlogPost
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\OneToMany(targetEntity: Tag::class, mappedBy: 'blogPost')]
-    protected Collection $tags;
+    private Collection $tags;
 
     /**
      * Never forget to initialize your collections!
@@ -459,13 +459,13 @@ class Tag
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: BlogPost::class, inversedBy: 'tags')]
-    protected ?BlogPost $blogPost = null;
+    private ?BlogPost $blogPost = null;
 
     #[ORM\Column(type: 'string')]
-    protected ?string $name = null;
+    private ?string $name = null;
 
     public function getId(): ?int
     {
@@ -533,10 +533,10 @@ use Doctrine\ORM\Mapping as ORM;
 class Tag
 {
     #[ORM\Column(type: 'string', nullable: true)]
-    protected ?string $postalCode = null;
+    private ?string $postalCode = null;
 
     #[ORM\Column(type: 'string', nullable: true)]
-    protected ?string $city = null;
+    private ?string $city = null;
 
     public function getPostalCode(): ?string
     {
@@ -574,13 +574,13 @@ class Person
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', nullable: true)]
-    protected ?string $name = null;
+    private ?string $name = null;
 
     #[ORM\Embedded(class: 'Address')]
-    protected Address $address;
+    private Address $address;
     
     /**
      * Similar to collections you should initialize embeddables in the constructor!
@@ -726,7 +726,7 @@ class BlogPost
     /** .. */
 
     #[ORM\OneToMany(targetEntity: Tag::class, mappedBy: 'blogPost', cascade: ['persist'])]
-    protected Collection $tags;
+    private Collection $tags;
 
     /** … */
 }
@@ -817,7 +817,7 @@ use Doctrine\ORM\Mapping as ORM;
 class SimpleEntity
 {
     #[ORM\Column(type: 'string')]
-    protected ?string $foo = null;
+    private ?string $foo = null;
 
     public function getFoo(): void
     {
@@ -884,10 +884,10 @@ class BlogPost
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\OneToMany(targetEntity: Tag::class, mappedBy: 'blogPost', cascade: ['persist'])]
-    protected Collection $tags;
+    private Collection $tags;
 
     /**
      * Never forget to initialize your collections!
@@ -938,13 +938,13 @@ class Tag
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: BlogPost::class, inversedBy: 'tags')]
-    protected ?BlogPost $blogPost = null;
+    private ?BlogPost $blogPost = null;
 
     #[ORM\Column(type: 'string')]
-    protected ?string $name = null;
+    private ?string $name = null;
 
     public function getId(): ?int
     {
@@ -1167,7 +1167,7 @@ use Laminas\Mvc\Controller\AbstractActionController
 
 class MySampleController extends AbstractActionController
 {
-    protected EntityManager $entityManager;
+    private EntityManager $entityManager;
     
     public function __construct(EntityManager $entityManager)
     {
@@ -1279,13 +1279,13 @@ class User
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id = null;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length=48)]
-    protected ?string $name = null;
+    private ?string $name = null;
 
     #[ORM\OneToOne(targetEntity: 'City')]
-    protected ?City $city = null;
+    private ?City $city = null;
 
     // … getter and setters are defined …
 }


### PR DESCRIPTION
As suggested by @greg0ire in #22, docs should always assume the latest PHP version. This PR updates the docs in several regards:

- All Doctrine annotations have been rewritten from DocBlock comments to PHP 8 attributes
- All classes have been rewritten to make use of typed properties (available from PHP 7.4)
- Class strings have been replaced through `::class` statements, classes have been imported
- Examples for controllers have been updated to include `EntityManager` as a dependency in the constructor, because the call `$this->getServiceLocator()` inside controllers has already been deprecated for a very long time and has been dropped in [laminas-mvc](https://packagist.org/packages/laminas/laminas-mvc) 3.0 (see [release notes](https://github.com/laminas/laminas-mvc/releases/tag/3.0.0))

As said, this only affects docs. Code of the library has not been changed.