### PR TITLE
Added support for PHP 8.1 and dropped PHP 7.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,14 +19,14 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         dependencies:
           - "highest"
         include:
-          - php-version: "7.2"
+          - php-version: "7.3"
             dependencies: "lowest"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,18 @@
         "rss": "https://github.com/doctrine/doctrine-laminas-hydrator/releases.atom"
     },
     "require": {
-        "php": "^7.2 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "ext-ctype": "*",
-        "doctrine/collections": "^1.6.5",
-        "doctrine/inflector": "^1.4.3 || ^2.0.3",
-        "doctrine/persistence": "^1.3.7 || ^2.0",
-        "laminas/laminas-hydrator": "^3.0.2 || ^4.0",
-        "laminas/laminas-stdlib": "^3.2.1"
+        "doctrine/collections": "^1.6.8",
+        "doctrine/inflector": "^1.4.4 || ^2.0.3",
+        "doctrine/persistence": "^1.3.8 || ^2.2.2",
+        "laminas/laminas-hydrator": "^3.2.1 || ^4.3.1",
+        "laminas/laminas-stdlib": "^3.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
-        "laminas/laminas-coding-standard": "^2.0"
+        "laminas/laminas-coding-standard": "^2.3.0",
+        "phpspec/prophecy-phpunit": "^2.0.1",
+        "phpunit/phpunit": "^9.5.9"
     },
     "autoload": {
         "psr-4": {

--- a/test/DoctrineObjectTest.php
+++ b/test/DoctrineObjectTest.php
@@ -16,6 +16,7 @@ use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
 use Laminas\Hydrator\Strategy\StrategyInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionClass;
 use stdClass;
 
@@ -27,6 +28,8 @@ use function time;
 
 class DoctrineObjectTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var DoctrineObjectHydrator */
     protected $hydratorByValue;
 


### PR DESCRIPTION
This PR drops support for PHP 7.2. Once support for PHP 7.2 is dropped, the required dependencies can all be updated to add support for PHP 8.1, hence, this PR provides support for PHP 8.1.

Essentially, the library itself remains unchanged. The only change is a small change in the test cases which was required because a deprecated message regarding prophesize (see sebastianbergmann/phpunit#4141) arised when upgrading from PHPunit 8.5 to 9.5.