### PR TITLE
add support for datetime_immutable and datetimetz_immutable

### DIFF
--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -613,10 +613,11 @@ class DoctrineObject extends AbstractHydrator
 
                 $isImmutable = substr($typeOfField, -9) === 'immutable';
 
-                if (
-                    ($isImmutable && $value instanceof DateTimeImmutable)
-                    || (! $isImmutable && $value instanceof DateTime)
-                ) {
+                // Psalm has troubles with nested conditions, therefore break this into two return statements.
+                // See https://github.com/vimeo/psalm/issues/6683.
+                if ($isImmutable && $value instanceof DateTimeImmutable) {
+                    return $value;
+                } elseif (! $isImmutable && $value instanceof DateTime) {
                     return $value;
                 } elseif ($isImmutable && $value instanceof DateTime) {
                     return DateTimeImmutable::createFromMutable($value);

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Laminas\Hydrator;
 
 use DateTime;
+use DateTimeImmutable;
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Laminas\Hydrator\Strategy\AllowRemoveByReference;
@@ -575,7 +576,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @param  mixed  $value
      * @param  string $typeOfField
-     * @return DateTime|null
+     * @return mixed|null
      */
     protected function handleTypeConversions($value, $typeOfField)
     {
@@ -601,25 +602,40 @@ class DoctrineObject extends AbstractHydrator
                 $value = (double) $value;
                 break;
             case 'datetimetz':
+            case 'datetimetz_immutable':
             case 'datetime':
+            case 'datetime_immutable':
             case 'time':
             case 'date':
                 if ($value === '') {
                     return null;
                 }
 
-                if ($value instanceof DateTime) {
+                $isImmutable = substr($typeOfField, -9) === 'immutable';
+
+                if (
+                    ($isImmutable && $value instanceof DateTimeImmutable)
+                    || (! $isImmutable && $value instanceof DateTime)
+                ) {
                     return $value;
+                } elseif ($isImmutable && $value instanceof DateTime) {
+                    return DateTimeImmutable::createFromMutable($value);
+                } elseif (! $isImmutable && $value instanceof DateTimeImmutable) {
+                    return DateTime::createFromImmutable($value);
                 }
 
                 if (is_int($value)) {
-                    $dateTime = new DateTime();
-                    $dateTime->setTimestamp($value);
-                    return $dateTime;
+                    $dateTime = $isImmutable
+                        ? new DateTimeImmutable()
+                        : new DateTime();
+
+                    return $dateTime->setTimestamp($value);
                 }
 
                 if (is_string($value)) {
-                    return new DateTime($value);
+                    return $isImmutable
+                        ? new DateTimeImmutable($value)
+                        : new DateTime($value);
                 }
 
                 break;

--- a/test/DoctrineObjectTypeConversionsTest.php
+++ b/test/DoctrineObjectTypeConversionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineTest\Laminas\Hydrator;
 
 use DateTime;
+use DateTimeImmutable;
 use Doctrine\Laminas\Hydrator\DoctrineObject as DoctrineObjectHydrator;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
@@ -230,7 +231,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($now, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
-        $now    = new DateTime();
+        $now    = new DateTimeImmutable();
         $data   = ['genericField' => clone $now];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
@@ -241,6 +242,54 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $entity = $this->hydratorByReference->hydrate($data, $entity);
 
         $this->assertInstanceOf('DateTime', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+    }
+
+    public function testHandleTypeConversionsDatetimeImmutable()
+    {
+        // When using hydration by value, it will use the public API of the entity to set values (setters)
+        $this->configureObjectManagerForSimpleEntityWithGenericField('datetime_immutable');
+
+        $entity = new Assets\SimpleEntityWithGenericField();
+        $now    = (new DateTimeImmutable())->setTimestamp(1522353676);
+        $data   = ['genericField' => 1522353676];
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = new Assets\SimpleEntityWithGenericField();
+        $now    = new DateTimeImmutable();
+        $data   = ['genericField' => $now->format('Y-m-d\TH:i:s\.u')];
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = new Assets\SimpleEntityWithGenericField();
+        $now    = new DateTime();
+        $data   = ['genericField' => clone $now];
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
         $this->assertEquals($now, $entity->getGenericField());
     }
 
@@ -279,7 +328,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($now, $entity->getGenericField());
 
         $entity = new Assets\SimpleEntityWithGenericField();
-        $now    = new DateTime();
+        $now    = new DateTimeImmutable();
         $data   = ['genericField' => clone $now];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
@@ -290,6 +339,54 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $entity = $this->hydratorByReference->hydrate($data, $entity);
 
         $this->assertInstanceOf('DateTime', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+    }
+
+    public function testHandleTypeConversionsDatetimetzImmutable()
+    {
+        // When using hydration by value, it will use the public API of the entity to set values (setters)
+        $this->configureObjectManagerForSimpleEntityWithGenericField('datetimetz_immutable');
+
+        $entity = new Assets\SimpleEntityWithGenericField();
+        $now    = (new DateTimeImmutable())->setTimestamp(1522353676);
+        $data   = ['genericField' => 1522353676];
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = new Assets\SimpleEntityWithGenericField();
+        $now    = new DateTimeImmutable();
+        $data   = ['genericField' => $now->format('Y-m-d\TH:i:s\.u')];
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = new Assets\SimpleEntityWithGenericField();
+        $now    = new DateTime();
+        $data   = ['genericField' => clone $now];
+
+        $entity = $this->hydratorByValue->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
+        $this->assertEquals($now, $entity->getGenericField());
+
+        $entity = $this->hydratorByReference->hydrate($data, $entity);
+
+        $this->assertInstanceOf('DateTimeImmutable', $entity->getGenericField());
         $this->assertEquals($now, $entity->getGenericField());
     }
 


### PR DESCRIPTION
This PR adds support for the doctrine `datetime_immutable `and `datetimetz_immutable` types.