### PR TITLE
Fixed broken website generation

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -2,7 +2,6 @@
   "active": true,
   "name": "Doctrine Laminas Hydrators",
   "slug": "doctrine-laminas-hydrators",
-  "docsSlug": "doctrine-laminas-hydrators",
   "versions": [
     {
       "name": "2.2",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # doctrine-laminas-hydrator
 
-[![Build Status](https://github.com/doctrine/doctrine-laminas-hydrator/workflows/Continuous%20Integration/badge.svg)](https://github.com/doctrine/doctrine-laminas-hydrator/actions?query=workflow%3A%22Continuous+Integration%22+branch%3A2.2.x)
-[![Coverage Status](https://codecov.io/gh/doctrine/doctrine-laminas-hydrator/branch/2.2.x/graph/badge.svg)](https://codecov.io/gh/doctrine/doctrine-laminas-hydrator/branch/2.2.x)
+[![Build Status](https://github.com/doctrine/doctrine-laminas-hydrator/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/doctrine-laminas-hydrator/actions/workflows/continuous-integration.yml?query=branch%3A2.2.x)
+[![Code Coverage](https://codecov.io/gh/doctrine/doctrine-laminas-hydrator/branch/2.2.x/graphs/badge.svg)](https://codecov.io/gh/doctrine/doctrine-laminas-hydrator/branch/2.2.x)
 [![Latest Stable Version](https://poser.pugx.org/doctrine/doctrine-laminas-hydrator/v/stable.png)](https://packagist.org/packages/doctrine/doctrine-laminas-hydrator)
 [![Total Downloads](https://poser.pugx.org/doctrine/doctrine-laminas-hydrator/downloads.png)](https://packagist.org/packages/doctrine/doctrine-laminas-hydrator)
 

--- a/docs/en/laminas-form.rst
+++ b/docs/en/laminas-form.rst
@@ -1,5 +1,5 @@
-A Complete Example using Laminas\Form
-=====================================
+A Complete Example using Laminas\\Form
+======================================
 
 Now that we understand how the hydrator works, let’s see how it
 integrates into the Laminas’ Form component. We are going to use a


### PR DESCRIPTION
This project is not yet listed on doctrine-project.org, but once it is added (I tested this locally) it breaks the website build with the following error:

```
Found unknown escape character "\F" at line 1 (near "title: "A Complete Example using Laminas\Form"").
```

This PR fixes the wrong escape sequence and removes the unneded `docsSlug` in the website settings.