### PR TITLE
Fixed mock in unit tests to return appropriate reflection classes

### DIFF
--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -78,20 +78,18 @@ class DoctrineObjectTest extends TestCase
             ->metadata
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('field')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'field') {
-                            return 'string';
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'field') {
+                        return 'string';
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -195,20 +193,18 @@ class DoctrineObjectTest extends TestCase
             ->metadata
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('done')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'done') {
-                            return 'boolean';
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'done') {
+                        return 'boolean';
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -258,20 +254,18 @@ class DoctrineObjectTest extends TestCase
             ->metadata
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('isActive')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'isActive') {
-                            return 'boolean';
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'isActive') {
+                        return 'boolean';
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -371,20 +365,18 @@ class DoctrineObjectTest extends TestCase
             ->metadata
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('date')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'date') {
-                            return 'datetime';
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'date') {
+                        return 'datetime';
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -434,24 +426,22 @@ class DoctrineObjectTest extends TestCase
                 $this->equalTo('embedded.field'),
                 $this->equalTo('embedded')
             ))
-            ->will(
-                $this->returnCallback(
-                    static function (string $arg): ?string {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'embedded.field') {
-                            return 'string';
-                        }
-
-                        if ($arg === 'embedded') {
-                            return null;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function (string $arg): ?string {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'embedded.field') {
+                        return 'string';
+                    }
+
+                    if ($arg === 'embedded') {
+                        return null;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -497,40 +487,36 @@ class DoctrineObjectTest extends TestCase
             ->metadata
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('toOne')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'toOne') {
-                            return Assets\ByValueDifferentiatorEntity::class;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'toOne') {
+                        return Assets\ByValueDifferentiatorEntity::class;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
             ->metadata
             ->method('hasAssociation')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('toOne')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return false;
-                        }
-
-                        if ($arg === 'toOne') {
-                            return true;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return false;
                     }
-                )
+
+                    if ($arg === 'toOne') {
+                        return true;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -589,24 +575,22 @@ class DoctrineObjectTest extends TestCase
                     $this->equalTo('field')
                 )
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'toOne') {
-                            return Assets\ByValueDifferentiatorEntity::class;
-                        }
-
-                        if ($arg === 'field') {
-                            return 'string';
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'toOne') {
+                        return Assets\ByValueDifferentiatorEntity::class;
+                    }
+
+                    if ($arg === 'field') {
+                        return 'string';
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -619,20 +603,18 @@ class DoctrineObjectTest extends TestCase
                     $this->equalTo('field')
                 )
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id' || $arg === 'field') {
-                            return false;
-                        }
-
-                        if ($arg === 'toOne') {
-                            return true;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id' || $arg === 'field') {
+                        return false;
                     }
-                )
+
+                    if ($arg === 'toOne') {
+                        return true;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -691,48 +673,44 @@ class DoctrineObjectTest extends TestCase
                     $this->equalTo('field')
                 )
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'field') {
-                            return 'string';
-                        }
-
-                        if ($arg === 'entities') {
-                            return ArrayCollection::class;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'field') {
+                        return 'string';
+                    }
+
+                    if ($arg === 'entities') {
+                        return ArrayCollection::class;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
             ->metadata
             ->method('hasAssociation')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('entities'), $this->equalTo('field')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return false;
-                        }
-
-                        if ($arg === 'field') {
-                            return false;
-                        }
-
-                        if ($arg === 'entities') {
-                            return true;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return false;
                     }
-                )
+
+                    if ($arg === 'field') {
+                        return false;
+                    }
+
+                    if ($arg === 'entities') {
+                        return true;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -796,48 +774,44 @@ class DoctrineObjectTest extends TestCase
                     $this->equalTo('field')
                 )
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'field') {
-                            return 'string';
-                        }
-
-                        if ($arg === 'entities') {
-                            return ArrayCollection::class;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'field') {
+                        return 'string';
+                    }
+
+                    if ($arg === 'entities') {
+                        return ArrayCollection::class;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
             ->metadata
             ->method('hasAssociation')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('entities')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return false;
-                        }
-
-                        if ($arg === 'field') {
-                            return 'string';
-                        }
-
-                        if ($arg === 'entities') {
-                            return true;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return false;
                     }
-                )
+
+                    if ($arg === 'field') {
+                        return 'string';
+                    }
+
+                    if ($arg === 'entities') {
+                        return true;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -1676,20 +1650,18 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        if ($arg['id'] === 3) {
-                            return $entityInDatabaseWithIdOfThree;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    if ($arg['id'] === 3) {
+                        return $entityInDatabaseWithIdOfThree;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
@@ -1741,20 +1713,18 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        if ($arg['id'] === 3) {
-                            return $entityInDatabaseWithIdOfThree;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    if ($arg['id'] === 3) {
+                        return $entityInDatabaseWithIdOfThree;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
@@ -1791,11 +1761,11 @@ class DoctrineObjectTest extends TestCase
         $this
             ->metadata
             ->method('getReflectionClass')
-            ->will($this->returnCallback(
+            ->willReturnCallback(
                 static function () use (&$reflSteps) {
                     return array_shift($reflSteps);
                 }
-            ));
+            );
 
         $this->configureObjectManagerForOneToManyEntity();
 
@@ -1822,20 +1792,18 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        if ($arg['id'] === 3) {
-                            return $entityInDatabaseWithIdOfThree;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    if ($arg['id'] === 3) {
+                        return $entityInDatabaseWithIdOfThree;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
@@ -1883,20 +1851,18 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        if ($arg['id'] === 3) {
-                            return $entityInDatabaseWithIdOfThree;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    if ($arg['id'] === 3) {
+                        return $entityInDatabaseWithIdOfThree;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
@@ -2061,20 +2027,18 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        if ($arg['id'] === 3) {
-                            return $entityInDatabaseWithIdOfThree;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    if ($arg['id'] === 3) {
+                        return $entityInDatabaseWithIdOfThree;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
@@ -2132,20 +2096,18 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        if ($arg['id'] === 3) {
-                            return $entityInDatabaseWithIdOfThree;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    if ($arg['id'] === 3) {
+                        return $entityInDatabaseWithIdOfThree;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
@@ -2204,20 +2166,18 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        if ($arg['id'] === 3) {
-                            return $entityInDatabaseWithIdOfThree;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    if ($arg['id'] === 3) {
+                        return $entityInDatabaseWithIdOfThree;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
@@ -2274,11 +2234,11 @@ class DoctrineObjectTest extends TestCase
             ->metadata
             ->expects($this->any())
             ->method('getReflectionClass')
-            ->will($this->returnCallback(
+            ->willReturnCallback(
                 static function () use (&$reflSteps) {
                     return array_shift($reflSteps);
                 }
-            ));
+            );
 
         $this->configureObjectManagerForOneToManyEntity();
 
@@ -2290,20 +2250,18 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        if ($arg['id'] === 3) {
-                            return $entityInDatabaseWithIdOfThree;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    if ($arg['id'] === 3) {
+                        return $entityInDatabaseWithIdOfThree;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $entity = $this->hydratorByReference->hydrate($data, $entity);
@@ -2385,16 +2343,14 @@ class DoctrineObjectTest extends TestCase
                 Assets\ByValueDifferentiatorEntity::class,
                 $this->logicalOr($this->equalTo(['id' => 2]), $this->equalTo(['id' => 3]))
             )
-            ->will(
-                $this->returnCallback(
-                    static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
-                        if ($arg['id'] === 2) {
-                            return $entityInDatabaseWithIdOfTwo;
-                        }
-
-                        return $entityInDatabaseWithIdOfThree;
+            ->willReturnCallback(
+                static function ($target, $arg) use ($entityInDatabaseWithIdOfTwo, $entityInDatabaseWithIdOfThree) {
+                    if ($arg['id'] === 2) {
+                        return $entityInDatabaseWithIdOfTwo;
                     }
-                )
+
+                    return $entityInDatabaseWithIdOfThree;
+                }
             );
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);

--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -1781,6 +1781,22 @@ class DoctrineObjectTest extends TestCase
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
+
+        $reflSteps = [
+            new ReflectionClass(Assets\OneToManyEntity::class),
+            new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
+            new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
+            new ReflectionClass(Assets\OneToManyEntity::class),
+        ];
+        $this
+            ->metadata
+            ->method('getReflectionClass')
+            ->will($this->returnCallback(
+                static function () use (&$reflSteps) {
+                    return array_shift($reflSteps);
+                }
+            ));
+
         $this->configureObjectManagerForOneToManyEntity();
 
         $data = [

--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -22,7 +22,6 @@ use ReflectionClass;
 use stdClass;
 
 use function array_keys;
-use function array_shift;
 use function assert;
 use function explode;
 use function implode;
@@ -1752,19 +1751,14 @@ class DoctrineObjectTest extends TestCase
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
 
-        $reflSteps = [
-            new ReflectionClass(Assets\OneToManyEntity::class),
-            new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
-            new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
-            new ReflectionClass(Assets\OneToManyEntity::class),
-        ];
         $this
             ->metadata
             ->method('getReflectionClass')
-            ->willReturnCallback(
-                static function () use (&$reflSteps) {
-                    return array_shift($reflSteps);
-                }
+            ->willReturnOnConsecutiveCalls(
+                new ReflectionClass(Assets\OneToManyEntity::class),
+                new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
+                new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
+                new ReflectionClass(Assets\OneToManyEntity::class)
             );
 
         $this->configureObjectManagerForOneToManyEntity();
@@ -2223,19 +2217,14 @@ class DoctrineObjectTest extends TestCase
             ])
         );
 
-        $reflSteps = [
-            new ReflectionClass(Assets\OneToManyEntityWithEntities::class),
-            new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
-            new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
-            new ReflectionClass(Assets\OneToManyEntityWithEntities::class),
-        ];
         $this
             ->metadata
             ->method('getReflectionClass')
-            ->willReturnCallback(
-                static function () use (&$reflSteps) {
-                    return array_shift($reflSteps);
-                }
+            ->willReturnOnConsecutiveCalls(
+                new ReflectionClass(Assets\OneToManyEntityWithEntities::class),
+                new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
+                new ReflectionClass(Assets\ByValueDifferentiatorEntity::class),
+                new ReflectionClass(Assets\OneToManyEntityWithEntities::class)
             );
 
         $this->configureObjectManagerForOneToManyEntity();

--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -51,7 +51,7 @@ class DoctrineObjectTest extends TestCase
         $this->metadata      = $this->createMock(ClassMetadata::class);
         $this->objectManager = $this->createMock(ObjectManager::class);
 
-        $this->objectManager->expects($this->any())
+        $this->objectManager
             ->method('getClassMetadata')
             ->will($this->returnValue($this->metadata));
     }
@@ -1845,7 +1845,6 @@ class DoctrineObjectTest extends TestCase
 
         $this
             ->objectManager
-            ->expects($this->any())
             ->method('find')
             ->with(
                 Assets\ByValueDifferentiatorEntity::class,
@@ -2232,7 +2231,6 @@ class DoctrineObjectTest extends TestCase
         ];
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getReflectionClass')
             ->willReturnCallback(
                 static function () use (&$reflSteps) {
@@ -2337,7 +2335,6 @@ class DoctrineObjectTest extends TestCase
 
         $this
             ->objectManager
-            ->expects($this->any())
             ->method('find')
             ->with(
                 Assets\ByValueDifferentiatorEntity::class,
@@ -2375,7 +2372,6 @@ class DoctrineObjectTest extends TestCase
 
         $this
             ->objectManager
-            ->expects($this->any())
             ->method('find')
             ->with(Assets\ByValueDifferentiatorEntity::class, '')
             ->will($this->returnValue($entityInDatabaseWithEmptyId));
@@ -2605,43 +2601,36 @@ class DoctrineObjectTest extends TestCase
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getName')
             ->will($this->returnValue(Assets\SimplePrivateEntity::class));
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getAssociationNames')
             ->will($this->returnValue([]));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getFieldNames')
             ->will($this->returnValue(['private', 'protected']));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('private'), $this->equalTo('protected')))
             ->will($this->returnValue('integer'));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('hasAssociation')
             ->will($this->returnValue(false));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getIdentifierFieldNames')
             ->will($this->returnValue(['private']));
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getReflectionClass')
             ->will($this->returnValue($refl));
 

--- a/tests/DoctrineObjectTypeConversionsTest.php
+++ b/tests/DoctrineObjectTypeConversionsTest.php
@@ -40,7 +40,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->metadata      = $this->createMock(ClassMetadata::class);
         $this->objectManager = $this->createMock(ObjectManager::class);
 
-        $this->objectManager->expects($this->any())
+        $this->objectManager
             ->method('getClassMetadata')
             ->will($this->returnValue($this->metadata));
     }
@@ -68,7 +68,6 @@ class DoctrineObjectTypeConversionsTest extends TestCase
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('genericField')))
             ->willReturnCallback(
@@ -147,7 +146,6 @@ class DoctrineObjectTypeConversionsTest extends TestCase
 
         $this
             ->metadata
-            ->expects($this->any())
             ->method('hasAssociation')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('toOne')))
             ->willReturnCallback(

--- a/tests/DoctrineObjectTypeConversionsTest.php
+++ b/tests/DoctrineObjectTypeConversionsTest.php
@@ -71,23 +71,21 @@ class DoctrineObjectTypeConversionsTest extends TestCase
             ->expects($this->any())
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('genericField')))
-            ->will(
-                $this->returnCallback(
-                    /**
-                     * @param string $arg
-                     */
-                    static function ($arg) use ($genericFieldType) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'genericField') {
-                            return $genericFieldType;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                /**
+                 * @param string $arg
+                 */
+                static function ($arg) use ($genericFieldType) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'genericField') {
+                        return $genericFieldType;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -133,20 +131,18 @@ class DoctrineObjectTypeConversionsTest extends TestCase
             ->metadata
             ->method('getTypeOfField')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('toOne')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return 'integer';
-                        }
-
-                        if ($arg === 'toOne') {
-                            return Assets\ByValueDifferentiatorEntity::class;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return 'integer';
                     }
-                )
+
+                    if ($arg === 'toOne') {
+                        return Assets\ByValueDifferentiatorEntity::class;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this
@@ -154,20 +150,18 @@ class DoctrineObjectTypeConversionsTest extends TestCase
             ->expects($this->any())
             ->method('hasAssociation')
             ->with($this->logicalOr($this->equalTo('id'), $this->equalTo('toOne')))
-            ->will(
-                $this->returnCallback(
-                    static function ($arg) {
-                        if ($arg === 'id') {
-                            return false;
-                        }
-
-                        if ($arg === 'toOne') {
-                            return true;
-                        }
-
-                        throw new InvalidArgumentException();
+            ->willReturnCallback(
+                static function ($arg) {
+                    if ($arg === 'id') {
+                        return false;
                     }
-                )
+
+                    if ($arg === 'toOne') {
+                        return true;
+                    }
+
+                    throw new InvalidArgumentException();
+                }
             );
 
         $this


### PR DESCRIPTION
In this test the reflection classes have not been mocked correctly. Though the current unit tests to not have any issues with it, the mocks should use the correct reflection classes, as otherwise updating variables via reflection will not work. See #44.

When adding the following debug code, one can see what is actually going wrong:


```php
    protected function hydrateByReference(array $data, $object)
    {
        $tryObject = $this->tryConvertArrayToObject($data, $object);
        $metadata  = $this->metadata;
        $refl      = $metadata->getReflectionClass();

        if (is_object($tryObject)) {
            $object = $tryObject;
        }

        // ADDITIONAL DEBUG CHECK START
        if (get_class($object) !== $refl->getName()) { 
            echo "\nObject:     " . get_class($object) . "\n";
            echo "Reflection: " . $refl->getName() . "\n";
        }
        // ADDITIONAL DEBUG CHECK END

        foreach ($data as $field => $value) {
            // [...]
        }

        return $object;
    }
```

Obviously, `get_class($object)` and `$refl->getName()` should always be identitcal, but in `testHydrateOneToManyAssociationByReferenceUsingIdentifiersArrayForRelations` they aren't:

```
Object:     DoctrineTest\Laminas\Hydrator\Assets\ByValueDifferentiatorEntity
Reflection: DoctrineTest\Laminas\Hydrator\Assets\OneToManyEntity
```

This PR fixes the test case to ensure that `ClassMetadata` is mocked correctly. Actually, in other test cases this is already implemented correctly, see for example in `testHydrateOneToManyAssociationByReferenceWithArrayCausingDataModifications`:

https://github.com/doctrine/doctrine-laminas-hydrator/blob/94e6cadcaa04166777a52eac577827f318a12ffa/tests/DoctrineObjectTest.php#L2242-L2281

This is simply transferred to `testHydrateOneToManyAssociationByReferenceUsingIdentifiersArrayForRelations`.