### PR TITLE
Drop PHP 7.3 and update dependencies

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -13,4 +13,4 @@ jobs:
     name: "Coding Standards"
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.3.0"
     with:
-      php-version: '8.0'
+      php-version: '8.1'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,4 +16,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.3.0"
     with:
-      php-versions: '["7.3", "7.4", "8.0", "8.1"]'
+      php-versions: '["7.4", "8.0", "8.1"]'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,4 +13,4 @@ jobs:
     name: "Static Analysis"
     uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.3.0"
     with:
-      php-version: '8.0'
+      php-version: '8.1'

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "keywords": [
         "doctrine",
         "hydrator",
-        "zf",
         "laminas"
     ],
     "support": {
@@ -14,13 +13,13 @@
         "rss": "https://github.com/doctrine/doctrine-laminas-hydrator/releases.atom"
     },
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-ctype": "*",
         "doctrine/collections": "^1.6.8",
-        "doctrine/inflector": "^1.4.4 || ^2.0.3",
-        "doctrine/persistence": "^1.3.8 || ^2.2.2",
-        "laminas/laminas-hydrator": "^3.2.1 || ^4.3.1",
-        "laminas/laminas-stdlib": "^3.6.0"
+        "doctrine/inflector": "^2.0.4",
+        "doctrine/persistence": "^2.2.3",
+        "laminas/laminas-hydrator": "^4.3.1",
+        "laminas/laminas-stdlib": "^3.6.1"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
@@ -28,7 +27,7 @@
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^1.1.2",
         "phpunit/phpunit": "^9.5.10",
-        "vimeo/psalm": "^4.10.0"
+        "vimeo/psalm": "^4.15.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
For the next major release, i.e. 3.0.0, we are going to drop support for PHP 7.3.

This allows to modernize the code, using typed properties. Furthermore, PHP 7.3 is now officially EOL. Laminas has started dropping support for PHP 7.3 in several in several packages already, so there is no need in supporting PHP 7.3 in new releases of our Laminas integrations anymore.