### PR TITLE
Introduce `CollectionStrategyInterface` and mark `AbstractCollectionStrategy` as internal

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,9 @@
 
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine">
+        <!-- Not used for consistency with the Laminas project -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
         <!-- This causes BC breaks, as method signatures (return type) change -->
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
         <!-- This causes BC breaks, as method signatures (parameter type) change -->

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -508,8 +508,8 @@ class DoctrineObject extends AbstractHydrator
 
     /**
      * Handle ToMany associations. In proper Doctrine design, Collections should not be swapped, so
-     * collections are always handled by reference. Internally, every collection is handled using specials
-     * strategies that inherit from CollectionStrategyInterface class, and that add or remove elements but without
+     * collections are always handled by reference. Internally, every collection is handled using
+     * strategies that implement CollectionStrategyInterface, and that add or remove elements but without
      * changing the collection of the object
      *
      * @param  object       $object

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -57,10 +57,10 @@ class DoctrineObject extends AbstractHydrator
     /** @var bool */
     protected $byValue = true;
 
-    /** @var class-string<Strategy\AbstractCollectionStrategy> */
+    /** @var class-string<Strategy\CollectionStrategyInterface> */
     protected $defaultByValueStrategy = AllowRemoveByValue::class;
 
-    /** @var class-string<Strategy\AbstractCollectionStrategy> */
+    /** @var class-string<Strategy\CollectionStrategyInterface> */
     protected $defaultByReferenceStrategy = AllowRemoveByReference::class;
 
     /** @var Inflector */
@@ -78,7 +78,7 @@ class DoctrineObject extends AbstractHydrator
     }
 
     /**
-     * @return class-string<Strategy\AbstractCollectionStrategy>
+     * @return class-string<Strategy\CollectionStrategyInterface>
      */
     public function getDefaultByValueStrategy()
     {
@@ -86,7 +86,7 @@ class DoctrineObject extends AbstractHydrator
     }
 
     /**
-     * @param class-string<Strategy\AbstractCollectionStrategy> $defaultByValueStrategy
+     * @param class-string<Strategy\CollectionStrategyInterface> $defaultByValueStrategy
      *
      * @return $this
      */
@@ -98,7 +98,7 @@ class DoctrineObject extends AbstractHydrator
     }
 
     /**
-     * @return class-string<Strategy\AbstractCollectionStrategy>
+     * @return class-string<Strategy\CollectionStrategyInterface>
      */
     public function getDefaultByReferenceStrategy()
     {
@@ -106,7 +106,7 @@ class DoctrineObject extends AbstractHydrator
     }
 
     /**
-     * @param class-string<Strategy\AbstractCollectionStrategy> $defaultByReferenceStrategy
+     * @param class-string<Strategy\CollectionStrategyInterface> $defaultByReferenceStrategy
      *
      * @return $this
      */
@@ -204,18 +204,18 @@ class DoctrineObject extends AbstractHydrator
 
             $strategy = $this->getStrategy($association);
 
-            if (! $strategy instanceof Strategy\AbstractCollectionStrategy) {
+            if (! $strategy instanceof Strategy\CollectionStrategyInterface) {
                 throw new InvalidArgumentException(
                     sprintf(
-                        'Strategies used for collections valued associations must inherit from '
-                        . 'Strategy\AbstractCollectionStrategy, %s given',
+                        'Strategies used for collections valued associations must inherit from %s, %s given',
+                        Strategy\CollectionStrategyInterface::class,
                         get_class($strategy)
                     )
                 );
             }
 
-            $strategy->setCollectionName($association)
-                ->setClassMetadata($this->metadata);
+            $strategy->setCollectionName($association);
+            $strategy->setClassMetadata($this->metadata);
         }
     }
 
@@ -509,7 +509,7 @@ class DoctrineObject extends AbstractHydrator
     /**
      * Handle ToMany associations. In proper Doctrine design, Collections should not be swapped, so
      * collections are always handled by reference. Internally, every collection is handled using specials
-     * strategies that inherit from AbstractCollectionStrategy class, and that add or remove elements but without
+     * strategies that inherit from CollectionStrategyInterface class, and that add or remove elements but without
      * changing the collection of the object
      *
      * @param  object       $object
@@ -593,9 +593,8 @@ class DoctrineObject extends AbstractHydrator
         );
 
         // Set the object so that the strategy can extract the Collection from it
-
         $collectionStrategy = $this->getStrategy($collectionName);
-        assert($collectionStrategy instanceof Strategy\AbstractCollectionStrategy);
+        assert($collectionStrategy instanceof Strategy\CollectionStrategyInterface);
         $collectionStrategy->setObject($object);
 
         // We could directly call hydrate method from the strategy, but if people want to override

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 
 namespace Doctrine\Laminas\Hydrator\Strategy;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use InvalidArgumentException;
-use Laminas\Hydrator\Strategy\StrategyInterface;
+use ReflectionException;
 
 use function get_class;
-use function is_object;
+use function is_array;
 use function method_exists;
 use function spl_object_hash;
 use function sprintf;
 use function strcmp;
 
-// phpcs:disable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix
-abstract class AbstractCollectionStrategy implements StrategyInterface
+/**
+ * @internal
+ */
+abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
 {
     /** @var string */
     protected $collectionName;
@@ -38,80 +41,32 @@ abstract class AbstractCollectionStrategy implements StrategyInterface
         $this->inflector = $inflector ?? InflectorFactory::create()->build();
     }
 
-    /**
-     * Set the name of the collection
-     *
-     * @param  string $collectionName
-     *
-     * @return $this
-     */
-    public function setCollectionName($collectionName)
+    public function setCollectionName(string $collectionName): void
     {
-        $this->collectionName = (string) $collectionName;
-
-        return $this;
+        $this->collectionName = $collectionName;
     }
 
-    /**
-     * Get the name of the collection
-     *
-     * @return string
-     */
-    public function getCollectionName()
+    public function getCollectionName(): string
     {
         return $this->collectionName;
     }
 
-    /**
-     * Set the class metadata
-     *
-     * @return $this
-     */
-    public function setClassMetadata(ClassMetadata $classMetadata)
+    public function setClassMetadata(ClassMetadata $classMetadata): void
     {
         $this->metadata = $classMetadata;
-
-        return $this;
     }
 
-    /**
-     * Get the class metadata
-     *
-     * @return ClassMetadata
-     */
-    public function getClassMetadata()
+    public function getClassMetadata(): ClassMetadata
     {
         return $this->metadata;
     }
 
-    /**
-     * Set the object
-     *
-     * @param  object $object
-     *
-     * @return $this
-     *
-     * @throws InvalidArgumentException
-     */
-    public function setObject($object)
+    public function setObject(object $object): void
     {
-        if (! is_object($object)) {
-            throw new InvalidArgumentException(
-                sprintf('The parameter given to setObject method of %s class is not an object', static::class)
-            );
-        }
-
         $this->object = $object;
-
-        return $this;
     }
 
-    /**
-     * Get the object
-     *
-     * @return object
-     */
-    public function getObject()
+    public function getObject(): object
     {
         return $this->object;
     }
@@ -120,7 +75,7 @@ abstract class AbstractCollectionStrategy implements StrategyInterface
      * Converts the given value so that it can be extracted by the hydrator.
      *
      * @param  mixed       $value  The original value.
-     * @param object|null $object (optional) The original object for context.
+     * @param  object|null $object (optional) The original object for context.
      *
      * @return mixed       Returns the value that should be extracted.
      */
@@ -132,11 +87,9 @@ abstract class AbstractCollectionStrategy implements StrategyInterface
     /**
      * Return the collection by value (using the public API)
      *
-     * @return Collection
-     *
      * @throws InvalidArgumentException
      */
-    protected function getCollectionFromObjectByValue()
+    protected function getCollectionFromObjectByValue(): Collection
     {
         $object = $this->getObject();
         $getter = 'get' . $this->inflector->classify($this->getCollectionName());
@@ -152,15 +105,21 @@ abstract class AbstractCollectionStrategy implements StrategyInterface
             );
         }
 
-        return $object->$getter();
+        $collection = $object->$getter();
+
+        if (is_array($collection)) {
+            $collection = new ArrayCollection($collection);
+        }
+
+        return $collection;
     }
 
     /**
      * Return the collection by reference (not using the public API)
      *
-     * @return Collection
+     * @throws InvalidArgumentException|ReflectionException
      */
-    protected function getCollectionFromObjectByReference()
+    protected function getCollectionFromObjectByReference(): Collection
     {
         $object       = $this->getObject();
         $refl         = $this->getClassMetadata()->getReflectionClass();
@@ -174,13 +133,8 @@ abstract class AbstractCollectionStrategy implements StrategyInterface
     /**
      * This method is used internally by array_udiff to check if two objects are equal, according to their
      * SPL hash. This is needed because the native array_diff only compare strings
-     *
-     * @param object $a
-     * @param object $b
-     *
-     * @return int
      */
-    protected function compareObjects($a, $b)
+    protected function compareObjects(object $a, object $b): int
     {
         return strcmp(spl_object_hash($a), spl_object_hash($b));
     }

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -17,7 +17,6 @@ use function is_array;
 use function method_exists;
 use function spl_object_hash;
 use function sprintf;
-use function strcmp;
 
 /**
  * @internal
@@ -136,6 +135,6 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
      */
     protected function compareObjects(object $a, object $b): int
     {
-        return strcmp(spl_object_hash($a), spl_object_hash($b));
+        return spl_object_hash($a) <=> spl_object_hash($b);
     }
 }

--- a/src/Strategy/AllowRemoveByValue.php
+++ b/src/Strategy/AllowRemoveByValue.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Laminas\Hydrator\Strategy;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use LogicException;
 
 use function array_udiff;
@@ -49,10 +48,7 @@ class AllowRemoveByValue extends AbstractCollectionStrategy
         }
 
         $collection = $this->getCollectionFromObjectByValue();
-
-        if ($collection instanceof Collection) {
-            $collection = $collection->toArray();
-        }
+        $collection = $collection->toArray();
 
         $toAdd    = new ArrayCollection(array_udiff($value, $collection, [$this, 'compareObjects']));
         $toRemove = new ArrayCollection(array_udiff($collection, $value, [$this, 'compareObjects']));

--- a/src/Strategy/CollectionStrategyInterface.php
+++ b/src/Strategy/CollectionStrategyInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Laminas\Hydrator\Strategy;
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Laminas\Hydrator\Strategy\StrategyInterface;
+
+interface CollectionStrategyInterface extends StrategyInterface
+{
+    /**
+     * Set the name of the collection
+     */
+    public function setCollectionName(string $collectionName): void;
+
+    /**
+     * Get the name of the collection
+     */
+    public function getCollectionName(): string;
+
+    /**
+     * Set the class metadata
+     */
+    public function setClassMetadata(ClassMetadata $classMetadata): void;
+
+    /**
+     * Get the class metadata
+     */
+    public function getClassMetadata(): ClassMetadata;
+
+    /**
+     * Set the object
+     */
+    public function setObject(object $object): void;
+
+    /**
+     * Get the object
+     */
+    public function getObject(): object;
+}

--- a/src/Strategy/DisallowRemoveByValue.php
+++ b/src/Strategy/DisallowRemoveByValue.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Laminas\Hydrator\Strategy;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use LogicException;
 
 use function array_udiff;
@@ -47,10 +46,7 @@ class DisallowRemoveByValue extends AbstractCollectionStrategy
         }
 
         $collection = $this->getCollectionFromObjectByValue();
-
-        if ($collection instanceof Collection) {
-            $collection = $collection->toArray();
-        }
+        $collection = $collection->toArray();
 
         $toAdd = new ArrayCollection(array_udiff($value, $collection, [$this, 'compareObjects']));
 


### PR DESCRIPTION
**Caution**: BC Break

For the upcoming 3.0.0 release, this PR marks `AbstractCollectionStrategy` as internal. As a replacement, the new interface `CollectionStrategyInterface` is introduced. Users writing their own stategies should consider implementing `CollectionStrategyInterface` instead of extending `AbstractCollectionStrategy`.

With the new interface, all relevant methods received typed signatures. Collection strategies must provide the following functions:

- From `Laminas\Hydrator\Strategy\StrategyInterface`:
  - `php public function extract($value, ?object $object = null);`
  - `public function hydrate($value, ?array $data);`
- From `Doctrine\Laminas\Hydrator\Strategy\CollectionStrategyInterface`:
  - `public function getCollectionName(): string;`
  - `public function setClassMetadata(ClassMetadata $classMetadata): void;`
  - `public function getClassMetadata(): ClassMetadata;`
  - `public function setObject(object $object): void;`
  - `public function getObject(): object;`
