### PR TITLE
Mark filters and strategies als final

### DIFF
--- a/src/Filter/PropertyName.php
+++ b/src/Filter/PropertyName.php
@@ -13,7 +13,7 @@ use function is_array;
  * Provides a filter to restrict returned fields by whitelisting or
  * blacklisting property names.
  */
-class PropertyName implements FilterInterface
+final class PropertyName implements FilterInterface
 {
     /**
      * The properties to exclude.

--- a/src/Strategy/AllowRemoveByReference.php
+++ b/src/Strategy/AllowRemoveByReference.php
@@ -13,7 +13,7 @@ use function array_udiff;
  * final collection will contain elements B and C (while element A will be asked to be removed).
  * This strategy is by reference, this means it won't use public API to add/remove elements to the collection
  */
-class AllowRemoveByReference extends AbstractCollectionStrategy
+final class AllowRemoveByReference extends AbstractCollectionStrategy
 {
     /**
      * Converts the given value so that it can be hydrated by the hydrator.

--- a/src/Strategy/AllowRemoveByValue.php
+++ b/src/Strategy/AllowRemoveByValue.php
@@ -19,7 +19,7 @@ use function sprintf;
  * final collection will contain elements B and C (while element A will be asked to be removed).
  * This strategy is by value, this means it will use the public API (in this case, adder and remover)
  */
-class AllowRemoveByValue extends AbstractCollectionStrategy
+final class AllowRemoveByValue extends AbstractCollectionStrategy
 {
     /**
      * Converts the given value so that it can be hydrated by the hydrator.

--- a/src/Strategy/DisallowRemoveByReference.php
+++ b/src/Strategy/DisallowRemoveByReference.php
@@ -13,7 +13,7 @@ use function array_udiff;
  * and C, then the final collection will contain elements A, B and C.
  * This strategy is by reference, this means it won't use the public API to remove elements
  */
-class DisallowRemoveByReference extends AbstractCollectionStrategy
+final class DisallowRemoveByReference extends AbstractCollectionStrategy
 {
     /**
      * Converts the given value so that it can be hydrated by the hydrator.

--- a/src/Strategy/DisallowRemoveByValue.php
+++ b/src/Strategy/DisallowRemoveByValue.php
@@ -19,7 +19,7 @@ use function sprintf;
  * and C, then the final collection will contain elements A, B and C.
  * This strategy is by value, this means it will use the public API (in this case, remover)
  */
-class DisallowRemoveByValue extends AbstractCollectionStrategy
+final class DisallowRemoveByValue extends AbstractCollectionStrategy
 {
     /**
      * Converts the given value so that it can be hydrated by the hydrator.

--- a/tests/Assets/DifferentAllowRemoveByReference.php
+++ b/tests/Assets/DifferentAllowRemoveByReference.php
@@ -4,8 +4,38 @@ declare(strict_types=1);
 
 namespace DoctrineTest\Laminas\Hydrator\Assets;
 
-use Doctrine\Laminas\Hydrator\Strategy\AllowRemoveByReference;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Laminas\Hydrator\Strategy\AbstractCollectionStrategy;
+use ReflectionException;
 
-class DifferentAllowRemoveByReference extends AllowRemoveByReference
+use function array_udiff;
+
+class DifferentAllowRemoveByReference extends AbstractCollectionStrategy
 {
+    /**
+     * @param mixed      $value
+     * @param array|null $data
+     *
+     * @return Collection|mixed
+     *
+     * @throws ReflectionException
+     */
+    public function hydrate($value, ?array $data)
+    {
+        $collection      = $this->getCollectionFromObjectByReference();
+        $collectionArray = $collection->toArray();
+
+        $toAdd    = array_udiff($value, $collectionArray, [$this, 'compareObjects']);
+        $toRemove = array_udiff($collectionArray, $value, [$this, 'compareObjects']);
+
+        foreach ($toAdd as $element) {
+            $collection->add($element);
+        }
+
+        foreach ($toRemove as $element) {
+            $collection->removeElement($element);
+        }
+
+        return $collection;
+    }
 }

--- a/tests/Assets/DifferentAllowRemoveByValue.php
+++ b/tests/Assets/DifferentAllowRemoveByValue.php
@@ -4,8 +4,50 @@ declare(strict_types=1);
 
 namespace DoctrineTest\Laminas\Hydrator\Assets;
 
-use Doctrine\Laminas\Hydrator\Strategy\AllowRemoveByValue;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Laminas\Hydrator\Strategy\AbstractCollectionStrategy;
+use LogicException;
 
-class DifferentAllowRemoveByValue extends AllowRemoveByValue
+use function array_udiff;
+use function get_class;
+use function method_exists;
+use function sprintf;
+
+class DifferentAllowRemoveByValue extends AbstractCollectionStrategy
 {
+    /**
+     * @param mixed      $value
+     * @param array|null $data
+     *
+     * @return array|mixed|mixed[]
+     */
+    public function hydrate($value, ?array $data)
+    {
+        // AllowRemove strategy need "adder" and "remover"
+        $adder   = 'add' . $this->inflector->classify($this->collectionName);
+        $remover = 'remove' . $this->inflector->classify($this->collectionName);
+
+        if (! method_exists($this->object, $adder) || ! method_exists($this->object, $remover)) {
+            throw new LogicException(
+                sprintf(
+                    'AllowRemove strategy for DoctrineModule hydrator requires both %s and %s to be defined in %s
+                     entity domain code, but one or both seem to be missing',
+                    $adder,
+                    $remover,
+                    get_class($this->object)
+                )
+            );
+        }
+
+        $collection = $this->getCollectionFromObjectByValue();
+        $collection = $collection->toArray();
+
+        $toAdd    = new ArrayCollection(array_udiff($value, $collection, [$this, 'compareObjects']));
+        $toRemove = new ArrayCollection(array_udiff($collection, $value, [$this, 'compareObjects']));
+
+        $this->object->$adder($toAdd);
+        $this->object->$remover($toRemove);
+
+        return $collection;
+    }
 }


### PR DESCRIPTION
**Caution:** BC Break

The filters and strategies delivered with doctrine-laminas-hydrator are now marked as final. They a no valid extension points anymore. In case users want to implement own filters or strategies, valid extension points are:

- `Laminas\Hydrator\Filter\FilterInterface` for filters
- `Laminas\Hydrator\Strategy\StrategyInterface` for strategies related to regular fields (i.e. no associations)
- `Doctrine\Laminas\Hydrator\Strategy\CollectionStrategyInterface` for collection strategies (i.e. association fields)