### PR TITLE
Added native parameter types and return types

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,8 @@
     <arg name="cache" value=".phpcs.cache"/>
     <arg name="colors"/>
 
-    <!-- set minimal required PHP version (7.3) -->
-    <config name="php_version" value="70300"/>
+    <!-- set minimal required PHP version (7.4) -->
+    <config name="php_version" value="70400"/>
 
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -44,8 +44,6 @@ use function sprintf;
 use function strpos;
 use function substr;
 
-use const PHP_VERSION_ID;
-
 class DoctrineObject extends AbstractHydrator
 {
     protected ObjectManager $objectManager;
@@ -269,7 +267,7 @@ class DoctrineObject extends AbstractHydrator
             $reflProperty->setAccessible(true);
 
             // skip uninitialized properties (available from PHP 7.4)
-            if (PHP_VERSION_ID >= 70400 && ! $reflProperty->isInitialized($object)) {
+            if (! $reflProperty->isInitialized($object)) {
                 continue;
             }
 

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -76,41 +76,33 @@ class DoctrineObject extends AbstractHydrator
     /**
      * @return class-string<Strategy\CollectionStrategyInterface>
      */
-    public function getDefaultByValueStrategy()
+    public function getDefaultByValueStrategy(): string
     {
         return $this->defaultByValueStrategy;
     }
 
     /**
      * @param class-string<Strategy\CollectionStrategyInterface> $defaultByValueStrategy
-     *
-     * @return $this
      */
-    public function setDefaultByValueStrategy($defaultByValueStrategy)
+    public function setDefaultByValueStrategy(string $defaultByValueStrategy): void
     {
         $this->defaultByValueStrategy = $defaultByValueStrategy;
-
-        return $this;
     }
 
     /**
      * @return class-string<Strategy\CollectionStrategyInterface>
      */
-    public function getDefaultByReferenceStrategy()
+    public function getDefaultByReferenceStrategy(): string
     {
         return $this->defaultByReferenceStrategy;
     }
 
     /**
      * @param class-string<Strategy\CollectionStrategyInterface> $defaultByReferenceStrategy
-     *
-     * @return $this
      */
-    public function setDefaultByReferenceStrategy($defaultByReferenceStrategy)
+    public function setDefaultByReferenceStrategy(string $defaultByReferenceStrategy): void
     {
         $this->defaultByReferenceStrategy = $defaultByReferenceStrategy;
-
-        return $this;
     }
 
     /**
@@ -151,7 +143,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * {@inheritDoc}
      */
-    public function hydrate(array $data, object $object)
+    public function hydrate(array $data, object $object): object
     {
         $this->prepare($object);
 
@@ -167,7 +159,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @param  object $object
      */
-    protected function prepare($object)
+    protected function prepare($object): void
     {
         $this->metadata = $this->objectManager->getClassMetadata(get_class($object));
         $this->prepareStrategies();
@@ -178,7 +170,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @throws InvalidArgumentException
      */
-    protected function prepareStrategies()
+    protected function prepareStrategies(): void
     {
         $associations = $this->metadata->getAssociationNames();
 
@@ -219,13 +211,9 @@ class DoctrineObject extends AbstractHydrator
      * Extract values from an object using a by-value logic (this means that it uses the entity
      * API, in this case, getters)
      *
-     * @param  object $object
-     *
-     * @return array
-     *
      * @throws RuntimeException
      */
-    protected function extractByValue($object)
+    protected function extractByValue(object $object): array
     {
         $methods = get_class_methods($object);
         $filter  = $object instanceof FilterProviderInterface
@@ -264,11 +252,9 @@ class DoctrineObject extends AbstractHydrator
      * Extract values from an object using a by-reference logic (this means that values are
      * directly fetched without using the public API of the entity, in this case, getters)
      *
-     * @param  object $object
-     *
      * @return array
      */
-    protected function extractByReference($object)
+    protected function extractByReference(object $object): array
     {
         $refl   = $this->metadata->getReflectionClass();
         $filter = $object instanceof FilterProviderInterface
@@ -321,17 +307,15 @@ class DoctrineObject extends AbstractHydrator
      * Hydrate the object using a by-value logic (this means that it uses the entity API, in this
      * case, setters)
      *
-     * @param  object $object
      * @psalm-param T $object
      *
-     * @return object
      * @psalm-return T
      *
      * @throws RuntimeException
      *
      * @template T of object
      */
-    protected function hydrateByValue(array $data, $object)
+    protected function hydrateByValue(array $data, ?object $object): object
     {
         $tryObject = $this->tryConvertArrayToObject($data, $object);
         $metadata  = $this->metadata;
@@ -385,15 +369,13 @@ class DoctrineObject extends AbstractHydrator
      * using the public API, in this case setters, and hence override any logic that could be done in those
      * setters)
      *
-     * @param  object $object
      * @psalm-param T $object
      *
-     * @return object
      * @psalm-return T
      *
      * @template T of object
      */
-    protected function hydrateByReference(array $data, $object)
+    protected function hydrateByReference(array $data, ?object $object): object
     {
         $tryObject = $this->tryConvertArrayToObject($data, $object);
         $metadata  = $this->metadata;
@@ -439,16 +421,14 @@ class DoctrineObject extends AbstractHydrator
      * an identifier for the object. This is useful in a context of updating existing entities, without ugly
      * tricks like setting manually the existing id directly into the entity
      *
-     * @param  array  $data   The data that may contain identifiers keys
-     * @param  object $object
+     * @param  array $data The data that may contain identifiers keys
      * @psalm-param T $object
      *
-     * @return object|null
      * @psalm-return T|null
      *
      * @template T of object
      */
-    protected function tryConvertArrayToObject($data, $object)
+    protected function tryConvertArrayToObject(array $data, object $object): ?object
     {
         $metadata         = $this->metadata;
         $identifierNames  = $metadata->getIdentifierFieldNames();
@@ -481,10 +461,8 @@ class DoctrineObject extends AbstractHydrator
      *
      * @param  class-string $target
      * @param  mixed        $value
-     *
-     * @return object|null
      */
-    protected function toOne($target, $value)
+    protected function toOne($target, $value): ?object
     {
         $metadata = $this->objectManager->getClassMetadata($target);
 
@@ -508,14 +486,12 @@ class DoctrineObject extends AbstractHydrator
      * strategies that implement CollectionStrategyInterface, and that add or remove elements but without
      * changing the collection of the object
      *
-     * @param  object       $object
-     * @param  mixed        $collectionName
      * @param  class-string $target
      * @param  mixed        $values
      *
      * @throws InvalidArgumentException
      */
-    protected function toMany($object, $collectionName, $target, $values)
+    protected function toMany(object $object, string $collectionName, string $target, $values)
     {
         $metadata   = $this->objectManager->getClassMetadata($target);
         $identifier = $metadata->getIdentifier();
@@ -603,12 +579,11 @@ class DoctrineObject extends AbstractHydrator
      *
      * @link http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/basic-mapping.html#doctrine-mapping-types
      *
-     * @param  mixed   $value
-     * @param  ?string $typeOfField
+     * @param  mixed $value
      *
      * @return mixed|null
      */
-    protected function handleTypeConversions($value, $typeOfField)
+    protected function handleTypeConversions($value, ?string $typeOfField)
     {
         if ($value === null) {
             return null;
@@ -686,16 +661,14 @@ class DoctrineObject extends AbstractHydrator
     /**
      * Find an object by a given target class and identifier
      *
-     * @param  mixed  $identifiers
-     * @param  string $targetClass
+     * @param  mixed $identifiers
      * @psalm-param class-string<T> $targetClass
      *
-     * @return object|null
      * @psalm-return T|null
      *
      * @template T of object
      */
-    protected function find($identifiers, $targetClass)
+    protected function find($identifiers, string $targetClass): ?object
     {
         if ($identifiers instanceof $targetClass) {
             return $identifiers;
@@ -712,10 +685,8 @@ class DoctrineObject extends AbstractHydrator
      * Verifies if a provided identifier is to be considered null
      *
      * @param  mixed $identifier
-     *
-     * @return bool
      */
-    private function isNullIdentifier($identifier)
+    private function isNullIdentifier($identifier): bool
     {
         if ($identifier === null) {
             return true;
@@ -742,12 +713,8 @@ class DoctrineObject extends AbstractHydrator
 
     /**
      * Check the field is nullable
-     *
-     * @param  string $name
-     *
-     * @return bool
      */
-    private function isNullable($name)
+    private function isNullable(string $name): bool
     {
         //TODO: need update after updating isNullable method of Doctrine\ORM\Mapping\ClassMetadata
         if ($this->metadata->hasField($name)) {
@@ -765,12 +732,8 @@ class DoctrineObject extends AbstractHydrator
 
     /**
      * Applies the naming strategy if there is one set
-     *
-     * @param string $field
-     *
-     * @return string
      */
-    protected function computeHydrateFieldName($field)
+    protected function computeHydrateFieldName(string $field): string
     {
         if ($this->hasNamingStrategy()) {
             $field = $this->getNamingStrategy()->hydrate($field);
@@ -781,12 +744,8 @@ class DoctrineObject extends AbstractHydrator
 
     /**
      * Applies the naming strategy if there is one set
-     *
-     * @param string $field
-     *
-     * @return string
      */
-    protected function computeExtractFieldName($field)
+    protected function computeExtractFieldName(string $field): string
     {
         if ($this->hasNamingStrategy()) {
             $field = $this->getNamingStrategy()->extract($field);

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -48,23 +48,19 @@ use const PHP_VERSION_ID;
 
 class DoctrineObject extends AbstractHydrator
 {
-    /** @var ObjectManager */
-    protected $objectManager;
+    protected ObjectManager $objectManager;
 
-    /** @var ClassMetadata */
-    protected $metadata;
+    protected ClassMetadata $metadata;
 
-    /** @var bool */
-    protected $byValue = true;
+    protected bool $byValue = true;
 
     /** @var class-string<Strategy\CollectionStrategyInterface> */
-    protected $defaultByValueStrategy = AllowRemoveByValue::class;
+    protected string $defaultByValueStrategy = AllowRemoveByValue::class;
 
     /** @var class-string<Strategy\CollectionStrategyInterface> */
-    protected $defaultByReferenceStrategy = AllowRemoveByReference::class;
+    protected string $defaultByReferenceStrategy = AllowRemoveByReference::class;
 
-    /** @var Inflector */
-    private $inflector;
+    private Inflector $inflector;
 
     /**
      * @param ObjectManager $objectManager The ObjectManager to use

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -251,8 +251,6 @@ class DoctrineObject extends AbstractHydrator
     /**
      * Extract values from an object using a by-reference logic (this means that values are
      * directly fetched without using the public API of the entity, in this case, getters)
-     *
-     * @return array
      */
     protected function extractByReference(object $object): array
     {

--- a/src/Filter/PropertyName.php
+++ b/src/Filter/PropertyName.php
@@ -15,19 +15,9 @@ use function is_array;
  */
 final class PropertyName implements FilterInterface
 {
-    /**
-     * The properties to exclude.
-     *
-     * @var array
-     */
-    protected $properties = [];
+    protected array $properties = [];
 
-    /**
-     * Either an exclude or an include.
-     *
-     * @var bool
-     */
-    protected $exclude;
+    protected bool $exclude;
 
     /**
      * @param string|array $properties The properties to exclude or include.

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -23,17 +23,13 @@ use function sprintf;
  */
 abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
 {
-    /** @var string */
-    protected $collectionName;
+    protected string $collectionName;
 
-    /** @var ClassMetadata */
-    protected $metadata;
+    protected ClassMetadata $metadata;
 
-    /** @var object */
-    protected $object;
+    protected object $object;
 
-    /** @var Inflector */
-    protected $inflector;
+    protected Inflector $inflector;
 
     public function __construct(?Inflector $inflector = null)
     {

--- a/tests/Assets/ByValueDifferentiatorEntity.php
+++ b/tests/Assets/ByValueDifferentiatorEntity.php
@@ -11,8 +11,7 @@ class ByValueDifferentiatorEntity
     /** @var string|int */
     protected $id;
 
-    /** @var string */
-    protected $field;
+    protected string $field;
 
     /**
      * @param string|int $id

--- a/tests/Assets/EmbedabbleEntity.php
+++ b/tests/Assets/EmbedabbleEntity.php
@@ -6,8 +6,7 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class EmbedabbleEntity
 {
-    /** @var string */
-    protected $field;
+    protected string $field;
 
     public function setField(string $field)
     {

--- a/tests/Assets/NamingStrategyEntity.php
+++ b/tests/Assets/NamingStrategyEntity.php
@@ -6,8 +6,7 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class NamingStrategyEntity
 {
-    /** @var string|null */
-    protected $camelCase;
+    protected ?string $camelCase = null;
 
     public function __construct(?string $camelCase = null)
     {

--- a/tests/Assets/OneToManyArrayEntity.php
+++ b/tests/Assets/OneToManyArrayEntity.php
@@ -11,7 +11,6 @@ class OneToManyArrayEntity
 {
     protected int $id;
 
-    /** @var Collection */
     protected Collection $entities;
 
     public function __construct()

--- a/tests/Assets/OneToManyArrayEntity.php
+++ b/tests/Assets/OneToManyArrayEntity.php
@@ -9,11 +9,10 @@ use Doctrine\Common\Collections\Collection;
 
 class OneToManyArrayEntity
 {
-    /** @var int */
-    protected $id;
+    protected int $id;
 
     /** @var Collection */
-    protected $entities;
+    protected Collection $entities;
 
     public function __construct()
     {

--- a/tests/Assets/OneToManyEntity.php
+++ b/tests/Assets/OneToManyEntity.php
@@ -11,7 +11,6 @@ class OneToManyEntity
 {
     protected int $id;
 
-    /** @var Collection */
     protected Collection $entities;
 
     public function __construct()

--- a/tests/Assets/OneToManyEntity.php
+++ b/tests/Assets/OneToManyEntity.php
@@ -9,11 +9,10 @@ use Doctrine\Common\Collections\Collection;
 
 class OneToManyEntity
 {
-    /** @var int */
-    protected $id;
+    protected int $id;
 
     /** @var Collection */
-    protected $entities;
+    protected Collection $entities;
 
     public function __construct()
     {

--- a/tests/Assets/OneToOneEntity.php
+++ b/tests/Assets/OneToOneEntity.php
@@ -8,14 +8,11 @@ use DateTime;
 
 class OneToOneEntity
 {
-    /** @var int */
-    protected $id;
+    protected int $id;
 
-    /** @var ByValueDifferentiatorEntity */
-    protected $toOne;
+    protected ?ByValueDifferentiatorEntity $toOne;
 
-    /** @var DateTime */
-    protected $createdAt;
+    protected DateTime $createdAt;
 
     public function setId(int $id)
     {

--- a/tests/Assets/OneToOneEntityNotNullable.php
+++ b/tests/Assets/OneToOneEntityNotNullable.php
@@ -6,11 +6,9 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class OneToOneEntityNotNullable
 {
-    /** @var int */
-    protected $id;
+    protected int $id;
 
-    /** @var ByValueDifferentiatorEntity */
-    protected $toOne;
+    protected ByValueDifferentiatorEntity $toOne;
 
     public function setId(int $id)
     {

--- a/tests/Assets/SimpleEntity.php
+++ b/tests/Assets/SimpleEntity.php
@@ -9,8 +9,7 @@ class SimpleEntity
     /** @var string|int */
     protected $id;
 
-    /** @var string */
-    protected $field;
+    protected string $field;
 
     /**
      * @param string|int $id

--- a/tests/Assets/SimpleEntityWithDateTime.php
+++ b/tests/Assets/SimpleEntityWithDateTime.php
@@ -8,11 +8,9 @@ use DateTime;
 
 class SimpleEntityWithDateTime
 {
-    /** @var int */
-    protected $id;
+    protected int $id;
 
-    /** @var DateTime */
-    protected $date;
+    protected ?DateTime $date;
 
     public function setId(int $id)
     {

--- a/tests/Assets/SimpleEntityWithEmbeddable.php
+++ b/tests/Assets/SimpleEntityWithEmbeddable.php
@@ -6,11 +6,9 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class SimpleEntityWithEmbeddable
 {
-    /** @var int */
-    protected $id;
+    protected int $id;
 
-    /** @var EmbedabbleEntity */
-    protected $embedded;
+    protected EmbedabbleEntity $embedded;
 
     public function __construct()
     {

--- a/tests/Assets/SimpleEntityWithGenericField.php
+++ b/tests/Assets/SimpleEntityWithGenericField.php
@@ -6,8 +6,7 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class SimpleEntityWithGenericField
 {
-    /** @var int */
-    protected $id;
+    protected int $id;
 
     /** @var mixed */
     protected $genericField;

--- a/tests/Assets/SimpleEntityWithIsBoolean.php
+++ b/tests/Assets/SimpleEntityWithIsBoolean.php
@@ -6,11 +6,9 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class SimpleEntityWithIsBoolean
 {
-    /** @var int */
-    protected $id;
+    protected int $id;
 
-    /** @var bool */
-    protected $isActive;
+    protected bool $isActive;
 
     public function setId(int $id)
     {

--- a/tests/Assets/SimpleIsEntity.php
+++ b/tests/Assets/SimpleIsEntity.php
@@ -9,8 +9,7 @@ class SimpleIsEntity
     /** @var int|string */
     protected $id;
 
-    /** @var bool */
-    protected $done;
+    protected bool $done;
 
     public function setId(int $id)
     {

--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -31,11 +31,9 @@ class DoctrineObjectTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var DoctrineObjectHydrator */
-    protected $hydratorByValue;
+    protected DoctrineObjectHydrator $hydratorByValue;
 
-    /** @var DoctrineObjectHydrator */
-    protected $hydratorByReference;
+    protected DoctrineObjectHydrator $hydratorByReference;
 
     /** @var ClassMetadata&MockObject */
     protected $metadata;

--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -892,9 +892,6 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'field' => 'foo'], $data);
     }
 
-    /**
-     * @requires PHP 7.4
-     */
     public function testDoesNotExtractUninitializedVariables()
     {
         // When using extraction by reference, it won't use the public API of entity (getters won't be called)

--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -2810,8 +2810,8 @@ class DoctrineObjectTest extends TestCase
         $objectManager
             ->getClassMetadata(Assets\ByValueDifferentiatorEntity::class)
             ->will([$byValueDifferentiatorEntity, 'reveal']);
-        $objectManager->find(Assets\OneToOneEntity::class, ['id' => 12])->willReturn(false);
-        $objectManager->find(Assets\ByValueDifferentiatorEntity::class, ['id' => 13])->willReturn(false);
+        $objectManager->find(Assets\OneToOneEntity::class, ['id' => 12])->willReturn(null);
+        $objectManager->find(Assets\ByValueDifferentiatorEntity::class, ['id' => 13])->willReturn(null);
 
         return $objectManager->reveal();
     }

--- a/tests/DoctrineObjectTypeConversionsTest.php
+++ b/tests/DoctrineObjectTypeConversionsTest.php
@@ -21,11 +21,9 @@ use function is_string;
 
 class DoctrineObjectTypeConversionsTest extends TestCase
 {
-    /** @var DoctrineObjectHydrator */
-    protected $hydratorByValue;
+    protected DoctrineObjectHydrator $hydratorByValue;
 
-    /** @var DoctrineObjectHydrator */
-    protected $hydratorByReference;
+    protected DoctrineObjectHydrator $hydratorByReference;
 
     /** @var ClassMetadata&MockObject */
     protected $metadata;


### PR DESCRIPTION
**Caution:** BC Break

This PR adds native parameter types and native return types in all places possible. This will be a BC break for people who are extending, for instance, `DoctrineObject`. Others should not be affected.