### PR TITLE
Make members of filters and strategies private

### DIFF
--- a/src/Filter/PropertyName.php
+++ b/src/Filter/PropertyName.php
@@ -15,15 +15,15 @@ use function is_array;
  */
 final class PropertyName implements FilterInterface
 {
-    protected array $properties = [];
+    private array $properties = [];
 
-    protected bool $exclude;
+    private bool $exclude;
 
     /**
      * @param string|array $properties The properties to exclude or include.
      * @param bool         $exclude    If the method should be excluded
      */
-    public function __construct($properties, $exclude = true)
+    public function __construct($properties, bool $exclude = true)
     {
         $this->exclude    = $exclude;
         $this->properties = is_array($properties)

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -11,6 +11,7 @@ use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use InvalidArgumentException;
 use ReflectionException;
+use RuntimeException;
 
 use function get_class;
 use function is_array;
@@ -23,13 +24,13 @@ use function sprintf;
  */
 abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
 {
-    protected string $collectionName;
+    private ?string $collectionName = null;
 
-    protected ClassMetadata $metadata;
+    private ?ClassMetadata $metadata = null;
 
-    protected object $object;
+    private ?object $object = null;
 
-    protected Inflector $inflector;
+    private Inflector $inflector;
 
     public function __construct(?Inflector $inflector = null)
     {
@@ -43,6 +44,10 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
 
     public function getCollectionName(): string
     {
+        if ($this->collectionName === null) {
+            throw new RuntimeException('Collection name has not been set.');
+        }
+
         return $this->collectionName;
     }
 
@@ -53,6 +58,10 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
 
     public function getClassMetadata(): ClassMetadata
     {
+        if ($this->metadata === null) {
+            throw new RuntimeException('Class metadata has not been set.');
+        }
+
         return $this->metadata;
     }
 
@@ -63,6 +72,10 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
 
     public function getObject(): object
     {
+        if ($this->object === null) {
+            throw new RuntimeException('Object has not been set.');
+        }
+
         return $this->object;
     }
 
@@ -79,6 +92,11 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
         return $value;
     }
 
+    protected function getInflector(): Inflector
+    {
+        return $this->inflector;
+    }
+
     /**
      * Return the collection by value (using the public API)
      *
@@ -87,7 +105,7 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
     protected function getCollectionFromObjectByValue(): Collection
     {
         $object = $this->getObject();
-        $getter = 'get' . $this->inflector->classify($this->getCollectionName());
+        $getter = 'get' . $this->getInflector()->classify($this->getCollectionName());
 
         if (! method_exists($object, $getter)) {
             throw new InvalidArgumentException(

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -10,8 +10,8 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use InvalidArgumentException;
+use LogicException;
 use ReflectionException;
-use RuntimeException;
 
 use function get_class;
 use function is_array;
@@ -45,7 +45,7 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
     public function getCollectionName(): string
     {
         if ($this->collectionName === null) {
-            throw new RuntimeException('Collection name has not been set.');
+            throw new LogicException('Collection name has not been set.');
         }
 
         return $this->collectionName;
@@ -59,7 +59,7 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
     public function getClassMetadata(): ClassMetadata
     {
         if ($this->metadata === null) {
-            throw new RuntimeException('Class metadata has not been set.');
+            throw new LogicException('Class metadata has not been set.');
         }
 
         return $this->metadata;
@@ -73,7 +73,7 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
     public function getObject(): object
     {
         if ($this->object === null) {
-            throw new RuntimeException('Object has not been set.');
+            throw new LogicException('Object has not been set.');
         }
 
         return $this->object;

--- a/src/Strategy/AllowRemoveByValue.php
+++ b/src/Strategy/AllowRemoveByValue.php
@@ -32,17 +32,18 @@ final class AllowRemoveByValue extends AbstractCollectionStrategy
     public function hydrate($value, ?array $data)
     {
         // AllowRemove strategy need "adder" and "remover"
-        $adder   = 'add' . $this->inflector->classify($this->collectionName);
-        $remover = 'remove' . $this->inflector->classify($this->collectionName);
+        $adder   = 'add' . $this->getInflector()->classify($this->getCollectionName());
+        $remover = 'remove' . $this->getInflector()->classify($this->getCollectionName());
+        $object  = $this->getObject();
 
-        if (! method_exists($this->object, $adder) || ! method_exists($this->object, $remover)) {
+        if (! method_exists($object, $adder) || ! method_exists($object, $remover)) {
             throw new LogicException(
                 sprintf(
                     'AllowRemove strategy for DoctrineModule hydrator requires both %s and %s to be defined in %s
                      entity domain code, but one or both seem to be missing',
                     $adder,
                     $remover,
-                    get_class($this->object)
+                    get_class($object)
                 )
             );
         }
@@ -53,8 +54,8 @@ final class AllowRemoveByValue extends AbstractCollectionStrategy
         $toAdd    = new ArrayCollection(array_udiff($value, $collection, [$this, 'compareObjects']));
         $toRemove = new ArrayCollection(array_udiff($collection, $value, [$this, 'compareObjects']));
 
-        $this->object->$adder($toAdd);
-        $this->object->$remover($toRemove);
+        $object->$adder($toAdd);
+        $object->$remover($toRemove);
 
         return $collection;
     }

--- a/src/Strategy/DisallowRemoveByValue.php
+++ b/src/Strategy/DisallowRemoveByValue.php
@@ -32,15 +32,16 @@ final class DisallowRemoveByValue extends AbstractCollectionStrategy
     public function hydrate($value, ?array $data)
     {
         // AllowRemove strategy need "adder"
-        $adder = 'add' . $this->inflector->classify($this->collectionName);
+        $adder  = 'add' . $this->getInflector()->classify($this->getCollectionName());
+        $object = $this->getObject();
 
-        if (! method_exists($this->object, $adder)) {
+        if (! method_exists($object, $adder)) {
             throw new LogicException(
                 sprintf(
                     'DisallowRemove strategy for DoctrineModule hydrator requires %s to
                      be defined in %s entity domain code, but it seems to be missing',
                     $adder,
-                    get_class($this->object)
+                    get_class($object)
                 )
             );
         }
@@ -50,7 +51,7 @@ final class DisallowRemoveByValue extends AbstractCollectionStrategy
 
         $toAdd = new ArrayCollection(array_udiff($value, $collection, [$this, 'compareObjects']));
 
-        $this->object->$adder($toAdd);
+        $object->$adder($toAdd);
 
         return $collection;
     }

--- a/tests/Assets/DifferentAllowRemoveByValue.php
+++ b/tests/Assets/DifferentAllowRemoveByValue.php
@@ -24,17 +24,18 @@ class DifferentAllowRemoveByValue extends AbstractCollectionStrategy
     public function hydrate($value, ?array $data)
     {
         // AllowRemove strategy need "adder" and "remover"
-        $adder   = 'add' . $this->inflector->classify($this->collectionName);
-        $remover = 'remove' . $this->inflector->classify($this->collectionName);
+        $adder   = 'add' . $this->getInflector()->classify($this->getCollectionName());
+        $remover = 'remove' . $this->getInflector()->classify($this->getCollectionName());
+        $object  = $this->getObject();
 
-        if (! method_exists($this->object, $adder) || ! method_exists($this->object, $remover)) {
+        if (! method_exists($object, $adder) || ! method_exists($object, $remover)) {
             throw new LogicException(
                 sprintf(
                     'AllowRemove strategy for DoctrineModule hydrator requires both %s and %s to be defined in %s
                      entity domain code, but one or both seem to be missing',
                     $adder,
                     $remover,
-                    get_class($this->object)
+                    get_class($object)
                 )
             );
         }
@@ -45,8 +46,8 @@ class DifferentAllowRemoveByValue extends AbstractCollectionStrategy
         $toAdd    = new ArrayCollection(array_udiff($value, $collection, [$this, 'compareObjects']));
         $toRemove = new ArrayCollection(array_udiff($collection, $value, [$this, 'compareObjects']));
 
-        $this->object->$adder($toAdd);
-        $this->object->$remover($toRemove);
+        $object->$adder($toAdd);
+        $object->$remover($toRemove);
 
         return $collection;
     }

--- a/tests/Filter/PropertyNameTest.php
+++ b/tests/Filter/PropertyNameTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineTest\Laminas\Hydrator\Filter;
+
+use Doctrine\Laminas\Hydrator\Filter\PropertyName;
+use PHPUnit\Framework\TestCase;
+
+class PropertyNameTest extends TestCase
+{
+    public function testAllowListProperties(): void
+    {
+        $filter = new PropertyName([
+            'property1',
+            'property2',
+        ], false);
+
+        $this->assertTrue($filter->filter('property1'));
+        $this->assertTrue($filter->filter('property2'));
+        $this->assertFalse($filter->filter('somethingElse'));
+    }
+
+    public function testDenyListProperties(): void
+    {
+        $filter = new PropertyName([
+            'property1',
+            'property2',
+        ], true);
+
+        $this->assertFalse($filter->filter('property1'));
+        $this->assertFalse($filter->filter('property2'));
+        $this->assertTrue($filter->filter('somethingElse'));
+    }
+
+    public function testDefaultIsDenyList(): void
+    {
+        $filter = new PropertyName([
+            'property1',
+            'property2',
+        ]);
+
+        $this->assertFalse($filter->filter('property1'));
+        $this->assertFalse($filter->filter('property2'));
+        $this->assertTrue($filter->filter('somethingElse'));
+    }
+}

--- a/tests/Strategy/AbstractCollectionStrategyTest.php
+++ b/tests/Strategy/AbstractCollectionStrategyTest.php
@@ -8,9 +8,9 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Laminas\Hydrator\Strategy\AbstractCollectionStrategy;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
-use RuntimeException;
 use stdClass;
 
 class AbstractCollectionStrategyTest extends TestCase
@@ -40,7 +40,7 @@ class AbstractCollectionStrategyTest extends TestCase
     public function testUninitializedCollectionNameThrowsException(): void
     {
         $strategy = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
-        $this->expectException(RuntimeException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Collection name has not been set.');
 
         $strategy->getCollectionName();
@@ -49,7 +49,7 @@ class AbstractCollectionStrategyTest extends TestCase
     public function testUninitializedClassMetadataThrowsException(): void
     {
         $strategy = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
-        $this->expectException(RuntimeException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Class metadata has not been set.');
 
         $strategy->getClassMetadata();
@@ -58,7 +58,7 @@ class AbstractCollectionStrategyTest extends TestCase
     public function testUninitializedObjectThrowsException(): void
     {
         $strategy = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
-        $this->expectException(RuntimeException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Object has not been set.');
 
         $strategy->getObject();

--- a/tests/Strategy/AbstractCollectionStrategyTest.php
+++ b/tests/Strategy/AbstractCollectionStrategyTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineTest\Laminas\Hydrator\Strategy;
+
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
+use Doctrine\Laminas\Hydrator\Strategy\AbstractCollectionStrategy;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use RuntimeException;
+use stdClass;
+
+class AbstractCollectionStrategyTest extends TestCase
+{
+    public function testDefaultInflector(): void
+    {
+        $strategy = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
+
+        $reflection = new ReflectionMethod(AbstractCollectionStrategy::class, 'getInflector');
+        $reflection->setAccessible(true);
+
+        $this->assertInstanceOf(Inflector::class, $reflection->invoke($strategy));
+    }
+
+    public function testCustomInflector(): void
+    {
+        $inflector = InflectorFactory::create()->build();
+        $strategy  = $this->getMockForAbstractClass(AbstractCollectionStrategy::class, [$inflector]);
+
+        $reflection = new ReflectionMethod(AbstractCollectionStrategy::class, 'getInflector');
+        $reflection->setAccessible(true);
+
+        $this->assertInstanceOf(Inflector::class, $reflection->invoke($strategy));
+        $this->assertSame($inflector, $reflection->invoke($strategy));
+    }
+
+    public function testUninitializedCollectionNameThrowsException(): void
+    {
+        $strategy = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Collection name has not been set.');
+
+        $strategy->getCollectionName();
+    }
+
+    public function testUninitializedClassMetadataThrowsException(): void
+    {
+        $strategy = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Class metadata has not been set.');
+
+        $strategy->getClassMetadata();
+    }
+
+    public function testUninitializedObjectThrowsException(): void
+    {
+        $strategy = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Object has not been set.');
+
+        $strategy->getObject();
+    }
+
+    public function testSetAndGetCollectionName(): void
+    {
+        $strategy       = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
+        $collectionName = 'sampleCollection';
+
+        $strategy->setCollectionName($collectionName);
+        $this->assertSame($collectionName, $strategy->getCollectionName());
+    }
+
+    public function testSetAndGetClassMetadata(): void
+    {
+        $strategy      = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
+        $classMetadata = $this->createStub(ClassMetadata::class);
+
+        $strategy->setClassMetadata($classMetadata);
+        $this->assertSame($classMetadata, $strategy->getClassMetadata());
+    }
+
+    public function testSetAndGetObject(): void
+    {
+        $strategy = $this->getMockForAbstractClass(AbstractCollectionStrategy::class);
+        $object   = new stdClass();
+
+        $strategy->setObject($object);
+        $this->assertSame($object, $strategy->getObject());
+    }
+}


### PR DESCRIPTION
**Caution:** BC Break

This makes member os filters and strategies private.

**For `PropertyName` filter**

The members `properties` and `exclude` are now private. As the class itself is marked `final`, this doesn't have any consequences. No getter/setter methods are provided.

**For `AbstractCollectionStrategy`**

The members which are are now private are:
- `collectionName` -> use `setCollectionName()` / `getCollectionName()` instead
- `classMetadata` -> use `setClassMetadata()` / `getClassMetadata()` instead
- `object` -> use `setObject()` / `getObject()` instead
- `inflector` -> use `getInflector()` instead, or set inflector using the constructor

While `AbstractCollectionStrategy` is marked as `internal` in 3.x, it wasn't internal in 2.x, so this will be a BC break for users upgrading from 2.x who have implemented their own strategies extending from `AbstractCollectionStrategy`.
