### PR TITLE
Make Psalm and PHPStan more strict

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
-    level: 5
+    level: 6
+    checkGenericClassInNonGenericObjectType: false
     paths:
         - src
         - tests

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="3"
+    errorLevel="2"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -221,6 +221,8 @@ class DoctrineObject extends AbstractHydrator
      * Extract values from an object using a by-value logic (this means that it uses the entity
      * API, in this case, getters)
      *
+     * @return array<string,mixed>
+     *
      * @throws RuntimeException
      */
     protected function extractByValue(object $object): array
@@ -261,6 +263,8 @@ class DoctrineObject extends AbstractHydrator
     /**
      * Extract values from an object using a by-reference logic (this means that values are
      * directly fetched without using the public API of the entity, in this case, getters)
+     *
+     * @return array<string,mixed>
      */
     protected function extractByReference(object $object): array
     {
@@ -294,9 +298,9 @@ class DoctrineObject extends AbstractHydrator
      * Converts a value for hydration
      * Apply strategies first, then the type conversions
      *
-     * @param string     $name  The name of the strategy to use.
-     * @param mixed      $value The value that should be converted.
-     * @param array|null $data  The whole data is optionally provided as context.
+     * @param string                       $name  The name of the strategy to use.
+     * @param mixed                        $value The value that should be converted.
+     * @param array<array-key, mixed>|null $data  The whole data is optionally provided as context.
      *
      * @return mixed|null
      */
@@ -315,6 +319,7 @@ class DoctrineObject extends AbstractHydrator
      * Hydrate the object using a by-value logic (this means that it uses the entity API, in this
      * case, setters)
      *
+     * @param array<string,mixed> $data
      * @psalm-param T $object
      *
      * @psalm-return T
@@ -377,6 +382,7 @@ class DoctrineObject extends AbstractHydrator
      * using the public API, in this case setters, and hence override any logic that could be done in those
      * setters)
      *
+     * @param array<string,mixed> $data
      * @psalm-param T $object
      *
      * @psalm-return T
@@ -429,7 +435,7 @@ class DoctrineObject extends AbstractHydrator
      * an identifier for the object. This is useful in a context of updating existing entities, without ugly
      * tricks like setting manually the existing id directly into the entity
      *
-     * @param  array $data The data that may contain identifiers keys
+     * @param array<string,mixed> $data The data that may contain identifiers keys
      * @psalm-param T $object
      *
      * @psalm-return T|null
@@ -690,7 +696,7 @@ class DoctrineObject extends AbstractHydrator
     /**
      * Verifies if a provided identifier is to be considered null
      *
-     * @param  mixed $identifier
+     * @param array<string|null>|mixed $identifier
      */
     private function isNullIdentifier($identifier): bool
     {
@@ -699,11 +705,6 @@ class DoctrineObject extends AbstractHydrator
         }
 
         if ($identifier instanceof Traversable || is_array($identifier)) {
-            // Psalm infers iterable as a union of array|Traversable, but
-            // ArrayUtils::iteratorToArray() doesn't accept iterable, so this
-            // needs to be overwritten manually here.
-            // See https://github.com/vimeo/psalm/issues/6682
-            /** @psalm-var array|Traversable $identifier */
             $nonNullIdentifiers = array_filter(
                 ArrayUtils::iteratorToArray($identifier),
                 static function ($value) {

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -64,10 +64,10 @@ class DoctrineObject extends AbstractHydrator
      * @param ObjectManager $objectManager The ObjectManager to use
      * @param bool          $byValue       If set to true, hydrator will always use entity's public API
      */
-    public function __construct(ObjectManager $objectManager, $byValue = true, ?Inflector $inflector = null)
+    public function __construct(ObjectManager $objectManager, bool $byValue = true, ?Inflector $inflector = null)
     {
         $this->objectManager = $objectManager;
-        $this->byValue       = (bool) $byValue;
+        $this->byValue       = $byValue;
         $this->inflector     = $inflector ?? InflectorFactory::create()->build();
     }
 
@@ -157,7 +157,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @param  object $object
      */
-    protected function prepare($object): void
+    protected function prepare(object $object): void
     {
         $this->metadata = $this->objectManager->getClassMetadata(get_class($object));
         $this->prepareStrategies();
@@ -282,8 +282,8 @@ class DoctrineObject extends AbstractHydrator
      * Converts a value for hydration
      * Apply strategies first, then the type conversions
      *
-     * @param  string     $name  The name of the strategy to use.
-     * @param  mixed      $value The value that should be converted.
+     * @param string     $name  The name of the strategy to use.
+     * @param mixed      $value The value that should be converted.
      * @param array|null $data  The whole data is optionally provided as context.
      *
      * @return mixed|null
@@ -458,7 +458,7 @@ class DoctrineObject extends AbstractHydrator
      * @param  class-string $target
      * @param  mixed        $value
      */
-    protected function toOne($target, $value): ?object
+    protected function toOne(string $target, $value): ?object
     {
         $metadata = $this->objectManager->getClassMetadata($target);
 
@@ -487,7 +487,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @throws InvalidArgumentException
      */
-    protected function toMany(object $object, string $collectionName, string $target, $values)
+    protected function toMany(object $object, string $collectionName, string $target, $values): void
     {
         $metadata   = $this->objectManager->getClassMetadata($target);
         $identifier = $metadata->getIdentifier();

--- a/src/Filter/PropertyName.php
+++ b/src/Filter/PropertyName.php
@@ -15,13 +15,14 @@ use function is_array;
  */
 final class PropertyName implements FilterInterface
 {
+    /** @var string[] */
     private array $properties = [];
 
     private bool $exclude;
 
     /**
-     * @param string|array $properties The properties to exclude or include.
-     * @param bool         $exclude    If the method should be excluded
+     * @param string|string[] $properties The properties to exclude or include.
+     * @param bool            $exclude    If the method should be excluded
      */
     public function __construct($properties, bool $exclude = true)
     {

--- a/src/Strategy/AllowRemoveByReference.php
+++ b/src/Strategy/AllowRemoveByReference.php
@@ -18,10 +18,10 @@ final class AllowRemoveByReference extends AbstractCollectionStrategy
     /**
      * Converts the given value so that it can be hydrated by the hydrator.
      *
-     * @param  mixed      $value The original value.
-     * @param array|null $data  The original data for context.
+     * @param mixed                        $value The original value.
+     * @param array<array-key, mixed>|null $data  The original data for context.
      *
-     * @return mixed      Returns the value that should be hydrated.
+     * @return mixed Returns the value that should be hydrated.
      */
     public function hydrate($value, ?array $data)
     {

--- a/src/Strategy/AllowRemoveByValue.php
+++ b/src/Strategy/AllowRemoveByValue.php
@@ -24,10 +24,10 @@ final class AllowRemoveByValue extends AbstractCollectionStrategy
     /**
      * Converts the given value so that it can be hydrated by the hydrator.
      *
-     * @param  mixed      $value The original value.
-     * @param array|null $data  The original data for context.
+     * @param mixed                        $value The original value.
+     * @param array<array-key, mixed>|null $data  The original data for context.
      *
-     * @return mixed      Returns the value that should be hydrated.
+     * @return mixed Returns the value that should be hydrated.
      */
     public function hydrate($value, ?array $data)
     {

--- a/src/Strategy/DisallowRemoveByReference.php
+++ b/src/Strategy/DisallowRemoveByReference.php
@@ -18,10 +18,10 @@ final class DisallowRemoveByReference extends AbstractCollectionStrategy
     /**
      * Converts the given value so that it can be hydrated by the hydrator.
      *
-     * @param  mixed      $value The original value.
-     * @param array|null $data  The original data for context.
+     * @param mixed                        $value The original value.
+     * @param array<array-key, mixed>|null $data  The original data for context.
      *
-     * @return mixed      Returns the value that should be hydrated.
+     * @return mixed Returns the value that should be hydrated.
      */
     public function hydrate($value, ?array $data)
     {

--- a/src/Strategy/DisallowRemoveByValue.php
+++ b/src/Strategy/DisallowRemoveByValue.php
@@ -24,10 +24,10 @@ final class DisallowRemoveByValue extends AbstractCollectionStrategy
     /**
      * Converts the given value so that it can be hydrated by the hydrator.
      *
-     * @param  mixed      $value The original value.
-     * @param array|null $data  The original data for context.
+     * @param mixed                        $value The original value.
+     * @param array<array-key, mixed>|null $data  The original data for context.
      *
-     * @return mixed      Returns the value that should be hydrated.
+     * @return mixed Returns the value that should be hydrated.
      */
     public function hydrate($value, ?array $data)
     {

--- a/tests/Assets/ByValueDifferentiatorEntity.php
+++ b/tests/Assets/ByValueDifferentiatorEntity.php
@@ -16,7 +16,7 @@ class ByValueDifferentiatorEntity
     /**
      * @param string|int $id
      */
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -29,7 +29,7 @@ class ByValueDifferentiatorEntity
         return $this->id;
     }
 
-    public function setField(string $field, bool $modifyValue = true)
+    public function setField(string $field, bool $modifyValue = true): void
     {
         // Modify the value to illustrate the difference between by value and by reference
         if ($modifyValue) {

--- a/tests/Assets/ContextStrategy.php
+++ b/tests/Assets/ContextStrategy.php
@@ -19,7 +19,8 @@ class ContextStrategy implements StrategyInterface
     }
 
     /**
-     * @param  mixed $value
+     * @param mixed                        $value
+     * @param array<array-key, mixed>|null $data
      *
      * @return mixed
      */

--- a/tests/Assets/DifferentAllowRemoveByReference.php
+++ b/tests/Assets/DifferentAllowRemoveByReference.php
@@ -13,8 +13,8 @@ use function array_udiff;
 class DifferentAllowRemoveByReference extends AbstractCollectionStrategy
 {
     /**
-     * @param mixed      $value
-     * @param array|null $data
+     * @param mixed                        $value
+     * @param array<array-key, mixed>|null $data
      *
      * @return Collection|mixed
      *

--- a/tests/Assets/DifferentAllowRemoveByValue.php
+++ b/tests/Assets/DifferentAllowRemoveByValue.php
@@ -16,8 +16,8 @@ use function sprintf;
 class DifferentAllowRemoveByValue extends AbstractCollectionStrategy
 {
     /**
-     * @param mixed      $value
-     * @param array|null $data
+     * @param mixed                        $value
+     * @param array<array-key, mixed>|null $data
      *
      * @return array|mixed|mixed[]
      */

--- a/tests/Assets/EmbedabbleEntity.php
+++ b/tests/Assets/EmbedabbleEntity.php
@@ -6,9 +6,9 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class EmbedabbleEntity
 {
-    protected string $field;
+    protected string $field = '';
 
-    public function setField(string $field)
+    public function setField(string $field): void
     {
         $this->field = $field;
     }

--- a/tests/Assets/NamingStrategyEntity.php
+++ b/tests/Assets/NamingStrategyEntity.php
@@ -13,7 +13,7 @@ class NamingStrategyEntity
         $this->camelCase = $camelCase;
     }
 
-    public function setCamelCase(?string $camelCase)
+    public function setCamelCase(?string $camelCase): void
     {
         $this->camelCase = $camelCase;
     }

--- a/tests/Assets/OneToManyArrayEntity.php
+++ b/tests/Assets/OneToManyArrayEntity.php
@@ -18,7 +18,7 @@ class OneToManyArrayEntity
         $this->entities = new ArrayCollection();
     }
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -28,7 +28,7 @@ class OneToManyArrayEntity
         return $this->id;
     }
 
-    public function addEntities(Collection $entities, bool $modifyValue = true)
+    public function addEntities(Collection $entities, bool $modifyValue = true): void
     {
         foreach ($entities as $entity) {
             // Modify the value to illustrate the difference between by value and by reference
@@ -40,13 +40,16 @@ class OneToManyArrayEntity
         }
     }
 
-    public function removeEntities(Collection $entities)
+    public function removeEntities(Collection $entities): void
     {
         foreach ($entities as $entity) {
             $this->entities->removeElement($entity);
         }
     }
 
+    /**
+     * @return object[]
+     */
     public function getEntities(bool $modifyValue = true): array
     {
         // Modify the value to illustrate the difference between by value and by reference

--- a/tests/Assets/OneToManyEntity.php
+++ b/tests/Assets/OneToManyEntity.php
@@ -18,7 +18,7 @@ class OneToManyEntity
         $this->entities = new ArrayCollection();
     }
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -28,7 +28,7 @@ class OneToManyEntity
         return $this->id;
     }
 
-    public function addEntities(Collection $entities, bool $modifyValue = true)
+    public function addEntities(Collection $entities, bool $modifyValue = true): void
     {
         foreach ($entities as $entity) {
             // Modify the value to illustrate the difference between by value and by reference
@@ -40,7 +40,7 @@ class OneToManyEntity
         }
     }
 
-    public function removeEntities(Collection $entities)
+    public function removeEntities(Collection $entities): void
     {
         foreach ($entities as $entity) {
             $this->entities->removeElement($entity);

--- a/tests/Assets/OneToOneEntity.php
+++ b/tests/Assets/OneToOneEntity.php
@@ -14,7 +14,7 @@ class OneToOneEntity
 
     protected DateTime $createdAt;
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -24,7 +24,7 @@ class OneToOneEntity
         return $this->id;
     }
 
-    public function setToOne(?ByValueDifferentiatorEntity $entity = null, bool $modifyValue = true)
+    public function setToOne(?ByValueDifferentiatorEntity $entity = null, bool $modifyValue = true): void
     {
         // Modify the value to illustrate the difference between by value and by reference
         if ($modifyValue && $entity !== null) {
@@ -45,7 +45,7 @@ class OneToOneEntity
         return $this->toOne;
     }
 
-    public function setCreatedAt(DateTime $createdAt)
+    public function setCreatedAt(DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }

--- a/tests/Assets/OneToOneEntityNotNullable.php
+++ b/tests/Assets/OneToOneEntityNotNullable.php
@@ -10,7 +10,7 @@ class OneToOneEntityNotNullable
 
     protected ByValueDifferentiatorEntity $toOne;
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -20,7 +20,7 @@ class OneToOneEntityNotNullable
         return $this->id;
     }
 
-    public function setToOne(ByValueDifferentiatorEntity $entity, bool $modifyValue = true)
+    public function setToOne(ByValueDifferentiatorEntity $entity, bool $modifyValue = true): void
     {
         // Modify the value to illustrate the difference between by value and by reference
         if ($modifyValue) {

--- a/tests/Assets/SimpleEntity.php
+++ b/tests/Assets/SimpleEntity.php
@@ -14,7 +14,7 @@ class SimpleEntity
     /**
      * @param string|int $id
      */
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -27,7 +27,7 @@ class SimpleEntity
         return $this->id;
     }
 
-    public function setField(string $field)
+    public function setField(string $field): void
     {
         $this->field = $field;
     }

--- a/tests/Assets/SimpleEntityPhp74.php
+++ b/tests/Assets/SimpleEntityPhp74.php
@@ -10,7 +10,7 @@ class SimpleEntityPhp74
 
     protected ?string $field;
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -20,7 +20,7 @@ class SimpleEntityPhp74
         return $this->id;
     }
 
-    public function setField(string $field)
+    public function setField(string $field): void
     {
         $this->field = $field;
     }

--- a/tests/Assets/SimpleEntityWithDateTime.php
+++ b/tests/Assets/SimpleEntityWithDateTime.php
@@ -12,7 +12,7 @@ class SimpleEntityWithDateTime
 
     protected ?DateTime $date;
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -22,7 +22,7 @@ class SimpleEntityWithDateTime
         return $this->id;
     }
 
-    public function setDate(?DateTime $date = null)
+    public function setDate(?DateTime $date = null): void
     {
         $this->date = $date;
     }

--- a/tests/Assets/SimpleEntityWithEmbeddable.php
+++ b/tests/Assets/SimpleEntityWithEmbeddable.php
@@ -15,7 +15,7 @@ class SimpleEntityWithEmbeddable
         $this->embedded = new EmbedabbleEntity();
     }
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -25,7 +25,7 @@ class SimpleEntityWithEmbeddable
         return $this->id;
     }
 
-    public function setEmbedded(EmbedabbleEntity $embedded)
+    public function setEmbedded(EmbedabbleEntity $embedded): void
     {
         $this->embedded = $embedded;
     }

--- a/tests/Assets/SimpleEntityWithGenericField.php
+++ b/tests/Assets/SimpleEntityWithGenericField.php
@@ -6,17 +6,17 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class SimpleEntityWithGenericField
 {
-    protected int $id;
+    protected ?int $id = null;
 
     /** @var mixed */
     protected $genericField;
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -24,7 +24,7 @@ class SimpleEntityWithGenericField
     /**
      * @param mixed $value
      */
-    public function setGenericField($value)
+    public function setGenericField($value): void
     {
         $this->genericField = $value;
     }

--- a/tests/Assets/SimpleEntityWithIsBoolean.php
+++ b/tests/Assets/SimpleEntityWithIsBoolean.php
@@ -10,7 +10,7 @@ class SimpleEntityWithIsBoolean
 
     protected bool $isActive;
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -20,9 +20,9 @@ class SimpleEntityWithIsBoolean
         return $this->id;
     }
 
-    public function setIsActive(bool $isActive)
+    public function setIsActive(bool $isActive): void
     {
-        $this->isActive = (bool) $isActive;
+        $this->isActive = $isActive;
     }
 
     public function isActive(): bool

--- a/tests/Assets/SimpleIsEntity.php
+++ b/tests/Assets/SimpleIsEntity.php
@@ -11,7 +11,7 @@ class SimpleIsEntity
 
     protected bool $done;
 
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -21,9 +21,9 @@ class SimpleIsEntity
         return $this->id;
     }
 
-    public function setDone(bool $done)
+    public function setDone(bool $done): void
     {
-        $this->done = (bool) $done;
+        $this->done = $done;
     }
 
     public function isDone(): bool

--- a/tests/Assets/SimplePrivateEntity.php
+++ b/tests/Assets/SimplePrivateEntity.php
@@ -14,7 +14,7 @@ class SimplePrivateEntity
      * @phpcsSuppress SlevomatCodingStandard.Classes.UnusedPrivateElements
      * @phpstan-ignore-next-line
      */
-    private function setPrivate($value)
+    private function setPrivate($value): void
     {
         throw new Exception('Should never be called');
     }
@@ -23,7 +23,7 @@ class SimplePrivateEntity
      * @phpcsSuppress SlevomatCodingStandard.Classes.UnusedPrivateElements
      * @phpstan-ignore-next-line
      */
-    private function getPrivate()
+    private function getPrivate(): void
     {
         throw new Exception('Should never be called');
     }
@@ -31,12 +31,12 @@ class SimplePrivateEntity
     /**
      * @param mixed $value
      */
-    protected function setProtected($value)
+    protected function setProtected($value): void
     {
         throw new Exception('Should never be called');
     }
 
-    protected function getProtected()
+    protected function getProtected(): void
     {
         throw new Exception('Should never be called');
     }

--- a/tests/Assets/SimpleStrategy.php
+++ b/tests/Assets/SimpleStrategy.php
@@ -19,7 +19,8 @@ class SimpleStrategy implements StrategyInterface
     }
 
     /**
-     * @param  mixed $value
+     * @param mixed                        $value
+     * @param array<array-key, mixed>|null $data
      *
      * @return mixed
      */

--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -53,7 +53,7 @@ class DoctrineObjectTest extends TestCase
             ->will($this->returnValue($this->metadata));
     }
 
-    public function configureObjectManagerForSimpleEntity(string $className = Assets\SimpleEntity::class)
+    public function configureObjectManagerForSimpleEntity(string $className = Assets\SimpleEntity::class): void
     {
         $refl = new ReflectionClass($className);
 
@@ -114,12 +114,12 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForByValueDifferentiatorEntity()
+    public function configureObjectManagerForByValueDifferentiatorEntity(): void
     {
         $this->configureObjectManagerForSimpleEntity(Assets\ByValueDifferentiatorEntity::class);
     }
 
-    public function configureObjectManagerForNamingStrategyEntity()
+    public function configureObjectManagerForNamingStrategyEntity(): void
     {
         $refl = new ReflectionClass(Assets\NamingStrategyEntity::class);
 
@@ -168,7 +168,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForSimpleIsEntity()
+    public function configureObjectManagerForSimpleIsEntity(): void
     {
         $refl = new ReflectionClass(Assets\SimpleIsEntity::class);
 
@@ -229,7 +229,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForSimpleEntityWithIsBoolean()
+    public function configureObjectManagerForSimpleEntityWithIsBoolean(): void
     {
         $refl = new ReflectionClass(Assets\SimpleEntityWithIsBoolean::class);
 
@@ -290,7 +290,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForSimpleEntityWithStringId(string $className = Assets\SimpleEntity::class)
+    public function configureObjectManagerForSimpleEntityWithStringId(string $className = Assets\SimpleEntity::class): void
     {
         $refl = new ReflectionClass($className);
 
@@ -339,12 +339,12 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForByValueDifferentiatorEntityWithStringId()
+    public function configureObjectManagerForByValueDifferentiatorEntityWithStringId(): void
     {
         $this->configureObjectManagerForSimpleEntityWithStringId(Assets\ByValueDifferentiatorEntity::class);
     }
 
-    public function configureObjectManagerForSimpleEntityWithDateTime()
+    public function configureObjectManagerForSimpleEntityWithDateTime(): void
     {
         $refl = new ReflectionClass(Assets\SimpleEntityWithDateTime::class);
 
@@ -401,7 +401,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForSimpleEntityWithEmbeddable()
+    public function configureObjectManagerForSimpleEntityWithEmbeddable(): void
     {
         $refl = new ReflectionClass(Assets\SimpleEntityWithEmbeddable::class);
 
@@ -466,7 +466,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForOneToOneEntity()
+    public function configureObjectManagerForOneToOneEntity(): void
     {
         $refl = new ReflectionClass(Assets\OneToOneEntity::class);
 
@@ -548,7 +548,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForOneToOneEntityNotNullable()
+    public function configureObjectManagerForOneToOneEntityNotNullable(): void
     {
         $refl = new ReflectionClass(Assets\OneToOneEntityNotNullable::class);
 
@@ -646,7 +646,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForOneToManyEntity()
+    public function configureObjectManagerForOneToManyEntity(): void
     {
         $refl = new ReflectionClass(Assets\OneToManyEntity::class);
 
@@ -747,7 +747,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForOneToManyArrayEntity()
+    public function configureObjectManagerForOneToManyArrayEntity(): void
     {
         $refl = new ReflectionClass(Assets\OneToManyArrayEntity::class);
 
@@ -848,7 +848,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function testObjectIsPassedForContextToStrategies()
+    public function testObjectIsPassedForContextToStrategies(): void
     {
         $entity = new Assets\SimpleEntity();
         $entity->setId(2);
@@ -866,7 +866,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => '3barbar', 'field' => 'bar'], $hydrator->extract($entity));
     }
 
-    public function testCanExtractSimpleEntityByValue()
+    public function testCanExtractSimpleEntityByValue(): void
     {
         // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
         $entity = new Assets\ByValueDifferentiatorEntity();
@@ -879,7 +879,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'field' => 'From getter: foo'], $data);
     }
 
-    public function testCanExtractSimpleEntityByReference()
+    public function testCanExtractSimpleEntityByReference(): void
     {
         // When using extraction by reference, it won't use the public API of entity (getters won't be called)
         $entity = new Assets\ByValueDifferentiatorEntity();
@@ -892,7 +892,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'field' => 'foo'], $data);
     }
 
-    public function testDoesNotExtractUninitializedVariables()
+    public function testDoesNotExtractUninitializedVariables(): void
     {
         // When using extraction by reference, it won't use the public API of entity (getters won't be called)
         $entity = new Assets\SimpleEntityPhp74();
@@ -908,7 +908,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'field' => 'value'], $data);
     }
 
-    public function testCanHydrateSimpleEntityByValue()
+    public function testCanHydrateSimpleEntityByValue(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\ByValueDifferentiatorEntity();
@@ -926,7 +926,7 @@ class DoctrineObjectTest extends TestCase
      *
      * @covers \Doctrine\Laminas\Hydrator\DoctrineObject::hydrateByValue
      */
-    public function testCanHydrateSimpleEntityWithStringIdByValue()
+    public function testCanHydrateSimpleEntityWithStringIdByValue(): void
     {
         $entity = new Assets\ByValueDifferentiatorEntity();
         $data   = ['id' => 'bar', 'field' => 'foo'];
@@ -939,7 +939,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals('From setter: foo', $entity->getField(false));
     }
 
-    public function testCanHydrateSimpleEntityByReference()
+    public function testCanHydrateSimpleEntityByReference(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $entity = new Assets\ByValueDifferentiatorEntity();
@@ -957,7 +957,7 @@ class DoctrineObjectTest extends TestCase
      *
      * @covers \Doctrine\Laminas\Hydrator\DoctrineObject::hydrateByReference
      */
-    public function testCanHydrateSimpleEntityWithStringIdByReference()
+    public function testCanHydrateSimpleEntityWithStringIdByReference(): void
     {
         $entity = new Assets\ByValueDifferentiatorEntity();
         $data   = ['id' => 'bar', 'field' => 'foo'];
@@ -970,7 +970,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals('foo', $entity->getField(false));
     }
 
-    public function testReuseExistingEntityIfDataArrayContainsIdentifier()
+    public function testReuseExistingEntityIfDataArrayContainsIdentifier(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $entity = new Assets\ByValueDifferentiatorEntity();
@@ -998,7 +998,7 @@ class DoctrineObjectTest extends TestCase
     /**
      * Test for https://github.com/doctrine/DoctrineModule/issues/456
      */
-    public function testReuseExistingEntityIfDataArrayContainsIdentifierWithZeroIdentifier()
+    public function testReuseExistingEntityIfDataArrayContainsIdentifierWithZeroIdentifier(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $entity = new Assets\ByValueDifferentiatorEntity();
@@ -1023,7 +1023,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals('bar', $entity->getField(false));
     }
 
-    public function testCanExtractSimpleEntityWithEmbeddableByValue()
+    public function testCanExtractSimpleEntityWithEmbeddableByValue(): void
     {
         // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
         $entity = new Assets\SimpleEntityWithEmbeddable();
@@ -1036,7 +1036,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'embedded' => $entity->getEmbedded()], $data);
     }
 
-    public function testCanExtractSimpleEntityWithEmbeddableByReference()
+    public function testCanExtractSimpleEntityWithEmbeddableByReference(): void
     {
         // When using extraction by reference, it won't use the public API of entity (getters won't be called)
         $entity = new Assets\SimpleEntityWithEmbeddable();
@@ -1049,7 +1049,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'embedded' => $entity->getEmbedded()], $data);
     }
 
-    public function testCanHydrateSimpleEntityWithEmbeddableByValue()
+    public function testCanHydrateSimpleEntityWithEmbeddableByValue(): void
     {
         // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
         $entity = new Assets\SimpleEntityWithEmbeddable();
@@ -1065,7 +1065,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entity->getEmbedded(), $embedded);
     }
 
-    public function testCanHydrateSimpleEntityWithEmbeddableByReference()
+    public function testCanHydrateSimpleEntityWithEmbeddableByReference(): void
     {
         // When using extraction by reference, it won't use the public API of entity (getters won't be called)
         $entity = new Assets\SimpleEntityWithEmbeddable();
@@ -1081,7 +1081,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entity->getEmbedded(), $embedded);
     }
 
-    public function testExtractOneToOneAssociationByValue()
+    public function testExtractOneToOneAssociationByValue(): void
     {
         // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
         $toOne = new Assets\ByValueDifferentiatorEntity();
@@ -1102,7 +1102,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($toOne, $data['toOne']);
     }
 
-    public function testExtractOneToOneAssociationByReference()
+    public function testExtractOneToOneAssociationByReference(): void
     {
         // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
         $toOne = new Assets\ByValueDifferentiatorEntity();
@@ -1123,7 +1123,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($toOne, $data['toOne']);
     }
 
-    public function testHydrateOneToOneAssociationByValue()
+    public function testHydrateOneToOneAssociationByValue(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $toOne = new Assets\ByValueDifferentiatorEntity();
@@ -1142,7 +1142,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals('Modified from setToOne setter', $entity->getToOne(false)->getField(false));
     }
 
-    public function testHydrateOneToOneAssociationByReference()
+    public function testHydrateOneToOneAssociationByReference(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $toOne = new Assets\ByValueDifferentiatorEntity();
@@ -1161,7 +1161,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals('foo', $entity->getToOne(false)->getField(false));
     }
 
-    public function testHydrateOneToOneAssociationByValueUsingIdentifierForRelation()
+    public function testHydrateOneToOneAssociationByValueUsingIdentifierForRelation(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToOneEntity();
@@ -1188,7 +1188,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfOne, $entity->getToOne(false));
     }
 
-    public function testHydrateOneToOneAssociationByReferenceUsingIdentifierForRelation()
+    public function testHydrateOneToOneAssociationByReferenceUsingIdentifierForRelation(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $entity = new Assets\OneToOneEntity();
@@ -1215,7 +1215,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfOne, $entity->getToOne(false));
     }
 
-    public function testHydrateOneToOneAssociationByValueUsingIdentifierArrayForRelation()
+    public function testHydrateOneToOneAssociationByValueUsingIdentifierArrayForRelation(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToOneEntity();
@@ -1242,7 +1242,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfOne, $entity->getToOne(false));
     }
 
-    public function testHydrateOneToOneAssociationByValueUsingFullArrayForRelation()
+    public function testHydrateOneToOneAssociationByValueUsingFullArrayForRelation(): void
     {
         $entity = new Assets\OneToOneEntityNotNullable();
         $this->configureObjectManagerForOneToOneEntityNotNullable();
@@ -1281,7 +1281,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function testHydrateOneToOneAssociationByReferenceUsingIdentifierArrayForRelation()
+    public function testHydrateOneToOneAssociationByReferenceUsingIdentifierArrayForRelation(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $entity = new Assets\OneToOneEntity();
@@ -1308,7 +1308,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfOne, $entity->getToOne(false));
     }
 
-    public function testCanHydrateOneToOneAssociationByValueWithNullableRelation()
+    public function testCanHydrateOneToOneAssociationByValueWithNullableRelation(): void
     {
         // When using hydration by value, it will use the public API of the entity to retrieve values (setters)
         $entity = new Assets\OneToOneEntity();
@@ -1323,7 +1323,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertNull($object->getToOne(false));
     }
 
-    public function testCanHydrateOneToOneAssociationByReferenceWithNullableRelation()
+    public function testCanHydrateOneToOneAssociationByReferenceWithNullableRelation(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to retrieve values (setters)
         $entity = new Assets\OneToOneEntity();
@@ -1338,7 +1338,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertNull($object->getToOne(false));
     }
 
-    public function testExtractOneToManyAssociationByValue()
+    public function testExtractOneToManyAssociationByValue(): void
     {
         // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1371,7 +1371,7 @@ class DoctrineObjectTest extends TestCase
     /**
      * @depends testExtractOneToManyAssociationByValue
      */
-    public function testExtractOneToManyByValueWithArray()
+    public function testExtractOneToManyByValueWithArray(): void
     {
         // When using extraction by value, it will use the public API of the entity to retrieve values (getters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1401,7 +1401,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($toMany2, $data['entities'][1]);
     }
 
-    public function testExtractOneToManyAssociationByReference()
+    public function testExtractOneToManyAssociationByReference(): void
     {
         // When using extraction by reference, it won't use the public API of the entity to retrieve values (getters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1434,7 +1434,7 @@ class DoctrineObjectTest extends TestCase
     /**
      * @depends testExtractOneToManyAssociationByReference
      */
-    public function testExtractOneToManyArrayByReference()
+    public function testExtractOneToManyArrayByReference(): void
     {
         // When using extraction by reference, it won't use the public API of the entity to retrieve values (getters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1464,7 +1464,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($toMany2, $data['entities'][1]);
     }
 
-    public function testHydrateOneToManyAssociationByValue()
+    public function testHydrateOneToManyAssociationByValue(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1504,7 +1504,7 @@ class DoctrineObjectTest extends TestCase
     /**
      * @depends testHydrateOneToManyAssociationByValue
      */
-    public function testHydrateOneToManyArrayByValue()
+    public function testHydrateOneToManyArrayByValue(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1541,7 +1541,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($toMany2, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByReference()
+    public function testHydrateOneToManyAssociationByReference(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1581,7 +1581,7 @@ class DoctrineObjectTest extends TestCase
     /**
      * @depends testHydrateOneToManyAssociationByReference
      */
-    public function testHydrateOneToManyArrayByReference()
+    public function testHydrateOneToManyArrayByReference(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1618,7 +1618,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($toMany2, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByValueUsingIdentifiersForRelations()
+    public function testHydrateOneToManyAssociationByValueUsingIdentifiersForRelations(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
@@ -1678,7 +1678,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByValueUsingIdentifiersArrayForRelations()
+    public function testHydrateOneToManyAssociationByValueUsingIdentifiersArrayForRelations(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
@@ -1741,7 +1741,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByReferenceUsingIdentifiersArrayForRelations()
+    public function testHydrateOneToManyAssociationByReferenceUsingIdentifiersArrayForRelations(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
@@ -1814,7 +1814,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByReferenceUsingIdentifiersForRelations()
+    public function testHydrateOneToManyAssociationByReferenceUsingIdentifiersForRelations(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
@@ -1872,7 +1872,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByValueUsingDisallowRemoveStrategy()
+    public function testHydrateOneToManyAssociationByValueUsingDisallowRemoveStrategy(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1923,7 +1923,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($toMany3, $entities[2]);
     }
 
-    public function testHydrateOneToManyAssociationByReferenceUsingDisallowRemoveStrategy()
+    public function testHydrateOneToManyAssociationByReferenceUsingDisallowRemoveStrategy(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $toMany1 = new Assets\ByValueDifferentiatorEntity();
@@ -1981,7 +1981,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($toMany3, $entities[2]);
     }
 
-    public function testHydrateOneToManyAssociationByValueWithArrayCausingDataModifications()
+    public function testHydrateOneToManyAssociationByValueWithArrayCausingDataModifications(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $data = [
@@ -2050,7 +2050,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByValueWithTraversableCausingDataModifications()
+    public function testHydrateOneToManyAssociationByValueWithTraversableCausingDataModifications(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $data = [
@@ -2119,7 +2119,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByValueWithStdClass()
+    public function testHydrateOneToManyAssociationByValueWithStdClass(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $stdClass1     = new stdClass();
@@ -2187,7 +2187,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
     }
 
-    public function testHydrateOneToManyAssociationByReferenceWithArrayCausingDataModifications()
+    public function testHydrateOneToManyAssociationByReferenceWithArrayCausingDataModifications(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $data = [
@@ -2267,7 +2267,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithIdOfThree, $entities[1]);
     }
 
-    public function testAssertCollectionsAreNotSwappedDuringHydration()
+    public function testAssertCollectionsAreNotSwappedDuringHydration(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
@@ -2295,7 +2295,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($initialCollection, $modifiedCollection);
     }
 
-    public function testAssertCollectionsAreNotSwappedDuringHydrationUsingIdentifiersForRelations()
+    public function testAssertCollectionsAreNotSwappedDuringHydrationUsingIdentifiersForRelations(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
@@ -2340,7 +2340,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($initialCollection, $modifiedCollection);
     }
 
-    public function testCanLookupsForEmptyIdentifiers()
+    public function testCanLookupsForEmptyIdentifiers(): void
     {
         // When using hydration by reference, it won't use the public API of the entity to set values (setters)
         $entity = new Assets\OneToManyEntity();
@@ -2373,7 +2373,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame($entityInDatabaseWithEmptyId, $entity);
     }
 
-    public function testHandleDateTimeConversionUsingByValue()
+    public function testHandleDateTimeConversionUsingByValue(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\SimpleEntityWithDateTime();
@@ -2388,7 +2388,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals($now, $entity->getDate()->getTimestamp());
     }
 
-    public function testEmptyStringIsNotConvertedToDateTime()
+    public function testEmptyStringIsNotConvertedToDateTime(): void
     {
         $entity = new Assets\SimpleEntityWithDateTime();
         $this->configureObjectManagerForSimpleEntityWithDateTime();
@@ -2400,7 +2400,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertNull($entity->getDate());
     }
 
-    public function testAssertNullValueHydratedForOneToOneWithOptionalMethodSignature()
+    public function testAssertNullValueHydratedForOneToOneWithOptionalMethodSignature(): void
     {
         $entity = new Assets\OneToOneEntity();
 
@@ -2413,7 +2413,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertNull($object->getToOne(false));
     }
 
-    public function testAssertNullValueNotUsedAsIdentifierForOneToOneWithNonOptionalMethodSignature()
+    public function testAssertNullValueNotUsedAsIdentifierForOneToOneWithNonOptionalMethodSignature(): void
     {
         $entity = new Assets\OneToOneEntityNotNullable();
 
@@ -2427,7 +2427,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertInstanceOf(Assets\ByValueDifferentiatorEntity::class, $object->getToOne(false));
     }
 
-    public function testUsesStrategyOnSimpleFieldsWhenHydratingByValue()
+    public function testUsesStrategyOnSimpleFieldsWhenHydratingByValue(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\ByValueDifferentiatorEntity();
@@ -2441,7 +2441,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals('From setter: modified while hydrating', $entity->getField(false));
     }
 
-    public function testUsesStrategyOnSimpleFieldsWhenHydratingByReference()
+    public function testUsesStrategyOnSimpleFieldsWhenHydratingByReference(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $entity = new Assets\ByValueDifferentiatorEntity();
@@ -2455,7 +2455,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals('modified while hydrating', $entity->getField(false));
     }
 
-    public function testUsesStrategyOnSimpleFieldsWhenExtractingByValue()
+    public function testUsesStrategyOnSimpleFieldsWhenExtractingByValue(): void
     {
         $entity = new Assets\ByValueDifferentiatorEntity();
         $entity->setId(2);
@@ -2469,7 +2469,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'field' => 'modified while extracting'], $data);
     }
 
-    public function testUsesStrategyOnSimpleFieldsWhenExtractingByReference()
+    public function testUsesStrategyOnSimpleFieldsWhenExtractingByReference(): void
     {
         $entity = new Assets\ByValueDifferentiatorEntity();
         $entity->setId(2);
@@ -2483,7 +2483,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'field' => 'modified while extracting'], $data);
     }
 
-    public function testCanExtractIsserByValue()
+    public function testCanExtractIsserByValue(): void
     {
         $entity = new Assets\SimpleIsEntity();
         $entity->setId(2);
@@ -2496,7 +2496,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'done' => true], $data);
     }
 
-    public function testCanExtractIsserThatStartsWithIsByValue()
+    public function testCanExtractIsserThatStartsWithIsByValue(): void
     {
         $entity = new Assets\SimpleEntityWithIsBoolean();
         $entity->setId(2);
@@ -2509,7 +2509,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id' => 2, 'isActive' => true], $data);
     }
 
-    public function testExtractWithPropertyNameFilterByValue()
+    public function testExtractWithPropertyNameFilterByValue(): void
     {
         $entity = new Assets\ByValueDifferentiatorEntity();
         $entity->setId(2);
@@ -2526,7 +2526,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id'], array_keys($data), 'Only the "id" field should have been extracted.');
     }
 
-    public function testExtractWithPropertyNameFilterByReference()
+    public function testExtractWithPropertyNameFilterByReference(): void
     {
         $entity = new Assets\ByValueDifferentiatorEntity();
         $entity->setId(2);
@@ -2543,7 +2543,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals(['id'], array_keys($data), 'Only the "id" field should have been extracted.');
     }
 
-    public function testExtractByReferenceUsesNamingStrategy()
+    public function testExtractByReferenceUsesNamingStrategy(): void
     {
         $this->configureObjectManagerForNamingStrategyEntity();
         $name = 'Foo';
@@ -2552,7 +2552,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals($name, $data['camel_case']);
     }
 
-    public function testExtractByValueUsesNamingStrategy()
+    public function testExtractByValueUsesNamingStrategy(): void
     {
         $this->configureObjectManagerForNamingStrategyEntity();
         $name = 'Bar';
@@ -2561,7 +2561,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals($name, $data['camel_case']);
     }
 
-    public function testHydrateByReferenceUsesNamingStrategy()
+    public function testHydrateByReferenceUsesNamingStrategy(): void
     {
         $this->configureObjectManagerForNamingStrategyEntity();
         $name = 'Baz';
@@ -2570,7 +2570,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals($name, $entity->getCamelCase());
     }
 
-    public function testHydrateByValueUsesNamingStrategy()
+    public function testHydrateByValueUsesNamingStrategy(): void
     {
         $this->configureObjectManagerForNamingStrategyEntity();
         $name = 'Qux';
@@ -2579,7 +2579,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals($name, $entity->getCamelCase());
     }
 
-    public function configureObjectManagerForSimplePrivateEntity()
+    public function configureObjectManagerForSimplePrivateEntity(): void
     {
         $refl = new ReflectionClass(Assets\SimplePrivateEntity::class);
 
@@ -2628,7 +2628,7 @@ class DoctrineObjectTest extends TestCase
         );
     }
 
-    public function testCannotHydratePrivateByValue()
+    public function testCannotHydratePrivateByValue(): void
     {
         $entity = new Assets\SimplePrivateEntity();
         $this->configureObjectManagerForSimplePrivateEntity();
@@ -2639,7 +2639,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertInstanceOf(Assets\SimplePrivateEntity::class, $entity);
     }
 
-    public function testDefaultStrategy()
+    public function testDefaultStrategy(): void
     {
         $this->configureObjectManagerForOneToManyEntity();
 
@@ -2673,7 +2673,7 @@ class DoctrineObjectTest extends TestCase
     /**
      * @depends testDefaultStrategy
      */
-    public function testOverrideDefaultStrategy()
+    public function testOverrideDefaultStrategy(): void
     {
         $this->configureObjectManagerForOneToManyEntity();
 
@@ -2710,7 +2710,7 @@ class DoctrineObjectTest extends TestCase
     /**
      * https://github.com/doctrine/DoctrineModule/issues/639
      */
-    public function testStrategyWithArrayByValue()
+    public function testStrategyWithArrayByValue(): void
     {
         $entity = new Assets\SimpleEntity();
 
@@ -2719,6 +2719,8 @@ class DoctrineObjectTest extends TestCase
         $this->hydratorByValue->addStrategy('field', new class implements StrategyInterface {
             /**
              * @param mixed $value
+             *
+             * @return string[]
              */
             public function extract($value, ?object $object = null): array
             {
@@ -2726,7 +2728,8 @@ class DoctrineObjectTest extends TestCase
             }
 
             /**
-             * @param mixed $value
+             * @param mixed    $value
+             * @param string[] $data
              */
             public function hydrate($value, ?array $data): string
             {
@@ -2739,7 +2742,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertEquals('complex,value', $entity->getField());
     }
 
-    public function testStrategyWithArrayByReference()
+    public function testStrategyWithArrayByReference(): void
     {
         $entity = new Assets\SimpleEntity();
 
@@ -2748,6 +2751,8 @@ class DoctrineObjectTest extends TestCase
         $this->hydratorByReference->addStrategy('field', new class implements StrategyInterface {
             /**
              * @param mixed $value
+             *
+             * @return string[]
              */
             public function extract($value, ?object $object = null): array
             {
@@ -2755,7 +2760,8 @@ class DoctrineObjectTest extends TestCase
             }
 
             /**
-             * @param mixed $value
+             * @param mixed    $value
+             * @param string[] $data
              */
             public function hydrate($value, ?array $data): string
             {
@@ -2813,7 +2819,7 @@ class DoctrineObjectTest extends TestCase
         return $objectManager->reveal();
     }
 
-    public function testNestedHydrationByValue()
+    public function testNestedHydrationByValue(): void
     {
         $objectManager = $this->getObjectManagerForNestedHydration();
         $hydrator      = new DoctrineObjectHydrator($objectManager, true);
@@ -2837,7 +2843,7 @@ class DoctrineObjectTest extends TestCase
         $this->assertSame('2019-01-24 12:00:00', $entity->getCreatedAt()->format('Y-m-d H:i:s'));
     }
 
-    public function testNestedHydrationByReference()
+    public function testNestedHydrationByReference(): void
     {
         $objectManager = $this->getObjectManagerForNestedHydration();
         $hydrator      = new DoctrineObjectHydrator($objectManager, false);

--- a/tests/DoctrineObjectTypeConversionsTest.php
+++ b/tests/DoctrineObjectTypeConversionsTest.php
@@ -46,7 +46,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
     /**
      * @param string|null $genericFieldType
      */
-    public function configureObjectManagerForSimpleEntityWithGenericField($genericFieldType)
+    public function configureObjectManagerForSimpleEntityWithGenericField($genericFieldType): void
     {
         $refl = new ReflectionClass(Assets\SimpleEntityWithGenericField::class);
 
@@ -110,7 +110,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         );
     }
 
-    public function configureObjectManagerForOneToOneEntity()
+    public function configureObjectManagerForOneToOneEntity(): void
     {
         $refl = new ReflectionClass(Assets\OneToOneEntity::class);
 
@@ -192,7 +192,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         );
     }
 
-    public function testHandleTypeConversionsDatetime()
+    public function testHandleTypeConversionsDatetime(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('datetime');
@@ -241,7 +241,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($now, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsDatetimeImmutable()
+    public function testHandleTypeConversionsDatetimeImmutable(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('datetime_immutable');
@@ -289,7 +289,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($now, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsDatetimetz()
+    public function testHandleTypeConversionsDatetimetz(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('datetimetz');
@@ -338,7 +338,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($now, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsDatetimetzImmutable()
+    public function testHandleTypeConversionsDatetimetzImmutable(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('datetimetz_immutable');
@@ -386,7 +386,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($now, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsTime()
+    public function testHandleTypeConversionsTime(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('time');
@@ -435,7 +435,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($now, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsDate()
+    public function testHandleTypeConversionsDate(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('date');
@@ -484,7 +484,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($now, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsInteger()
+    public function testHandleTypeConversionsInteger(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('integer');
@@ -508,7 +508,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($value, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsSmallint()
+    public function testHandleTypeConversionsSmallint(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('smallint');
@@ -532,7 +532,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($value, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsFloat()
+    public function testHandleTypeConversionsFloat(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('float');
@@ -556,7 +556,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals($value, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsBoolean()
+    public function testHandleTypeConversionsBoolean(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('boolean');
@@ -594,7 +594,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals(true, $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsString()
+    public function testHandleTypeConversionsString(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('string');
@@ -640,7 +640,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals('12345', $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsText()
+    public function testHandleTypeConversionsText(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('text');
@@ -686,7 +686,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals('12345', $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsBigint()
+    public function testHandleTypeConversionsBigint(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('bigint');
@@ -732,7 +732,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals('12345', $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsDecimal()
+    public function testHandleTypeConversionsDecimal(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField('decimal');
@@ -778,7 +778,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertEquals('12345', $entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsNullable()
+    public function testHandleTypeConversionsNullable(): void
     {
         // When using hydration by value, it will use the public API of the entity to set values (setters)
         $this->configureObjectManagerForSimpleEntityWithGenericField(null);
@@ -798,7 +798,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->assertNull($entity->getGenericField());
     }
 
-    public function testHandleTypeConversionsNullableForAssociatedFields()
+    public function testHandleTypeConversionsNullableForAssociatedFields(): void
     {
         $this->configureObjectManagerForOneToOneEntity();
 


### PR DESCRIPTION
This PR lowers Psalm level from 3 to 2 and raises PHPStan level from 5 to 6.

As a few signatures received native types, this is a BC break. It is targeted at the upcoming 3.0.0 release.