### PR TITLE
Improved type hints for collections

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,13 +21,5 @@
         <!-- Not used for consistency with the Laminas project -->
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
-        <!-- This causes BC breaks, as method signatures (return type) change -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
-        <!-- This causes BC breaks, as method signatures (parameter type) change -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
-        <!-- This is simply too noisy for now -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
     </rule>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,5 +4,9 @@ parameters:
     paths:
         - src
         - tests
+    ignoreErrors:
+        -
+          message: '#expects .*Collection<\(int\|string\), object>, .*ArrayCollection<int, Doctrine.*Entity> given#'
+          path: tests/DoctrineObjectTest.php
 includes:
 	- vendor/jangregor/phpstan-prophecy/extension.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
-    <testsuites>
-        <testsuite name="doctrine-laminas-hydrator">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="doctrine-laminas-hydrator">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -138,6 +138,8 @@ class DoctrineObject extends AbstractHydrator
 
     /**
      * Extract values from an object
+     *
+     * @return array<array-key,mixed>
      */
     public function extract(object $object): array
     {

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -100,6 +100,8 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
     /**
      * Return the collection by value (using the public API)
      *
+     * @return Collection<array-key,object>
+     *
      * @throws InvalidArgumentException
      */
     protected function getCollectionFromObjectByValue(): Collection
@@ -129,6 +131,8 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
 
     /**
      * Return the collection by reference (not using the public API)
+     *
+     * @return Collection<array-key,object>
      *
      * @throws InvalidArgumentException|ReflectionException
      */

--- a/tests/Assets/DifferentAllowRemoveByReference.php
+++ b/tests/Assets/DifferentAllowRemoveByReference.php
@@ -13,14 +13,14 @@ use function array_udiff;
 class DifferentAllowRemoveByReference extends AbstractCollectionStrategy
 {
     /**
-     * @param mixed                        $value
-     * @param array<array-key, mixed>|null $data
+     * @param mixed                       $value
+     * @param array<array-key,mixed>|null $data
      *
-     * @return Collection|mixed
+     * @return Collection<array-key,mixed>
      *
      * @throws ReflectionException
      */
-    public function hydrate($value, ?array $data)
+    public function hydrate($value, ?array $data): Collection
     {
         $collection      = $this->getCollectionFromObjectByReference();
         $collectionArray = $collection->toArray();

--- a/tests/Assets/OneToManyArrayEntity.php
+++ b/tests/Assets/OneToManyArrayEntity.php
@@ -11,6 +11,7 @@ class OneToManyArrayEntity
 {
     protected int $id;
 
+    /** @var Collection<array-key,object> */
     protected Collection $entities;
 
     public function __construct()
@@ -28,6 +29,9 @@ class OneToManyArrayEntity
         return $this->id;
     }
 
+    /**
+     * @psalm-param Collection<array-key,object> $entities
+     */
     public function addEntities(Collection $entities, bool $modifyValue = true): void
     {
         foreach ($entities as $entity) {
@@ -40,6 +44,9 @@ class OneToManyArrayEntity
         }
     }
 
+    /**
+     * @param Collection<array-key,object> $entities
+     */
     public function removeEntities(Collection $entities): void
     {
         foreach ($entities as $entity) {

--- a/tests/Assets/OneToManyEntity.php
+++ b/tests/Assets/OneToManyEntity.php
@@ -11,6 +11,7 @@ class OneToManyEntity
 {
     protected int $id;
 
+    /** @var Collection<array-key,object> */
     protected Collection $entities;
 
     public function __construct()
@@ -28,6 +29,9 @@ class OneToManyEntity
         return $this->id;
     }
 
+    /**
+     * @param Collection<array-key,object> $entities
+     */
     public function addEntities(Collection $entities, bool $modifyValue = true): void
     {
         foreach ($entities as $entity) {
@@ -40,6 +44,9 @@ class OneToManyEntity
         }
     }
 
+    /**
+     * @param Collection<array-key,object> $entities
+     */
     public function removeEntities(Collection $entities): void
     {
         foreach ($entities as $entity) {
@@ -47,6 +54,9 @@ class OneToManyEntity
         }
     }
 
+    /**
+     * @return Collection<array-key,object>
+     */
     public function getEntities(bool $modifyValue = true): Collection
     {
         // Modify the value to illustrate the difference between by value and by reference

--- a/tests/Assets/OneToManyEntityWithEntities.php
+++ b/tests/Assets/OneToManyEntityWithEntities.php
@@ -14,6 +14,9 @@ class OneToManyEntityWithEntities extends OneToManyEntity
         $this->entities = $entities;
     }
 
+    /**
+     * @return Collection<array-key,object>
+     */
     public function getEntities(bool $modifyValue = true): Collection
     {
         return $this->entities;

--- a/tests/DoctrineObjectTypeConversionsTest.php
+++ b/tests/DoctrineObjectTypeConversionsTest.php
@@ -43,10 +43,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
             ->will($this->returnValue($this->metadata));
     }
 
-    /**
-     * @param string|null $genericFieldType
-     */
-    public function configureObjectManagerForSimpleEntityWithGenericField($genericFieldType): void
+    public function configureObjectManagerForSimpleEntityWithGenericField(?string $genericFieldType): void
     {
         $refl = new ReflectionClass(Assets\SimpleEntityWithGenericField::class);
 


### PR DESCRIPTION
As the 3.0.0 release is fully typed, we can drop a few exceptions from PHPCs config. This requires just a few more type hints for collections for CI to pass.