### PR TITLE
Use strcmp instead of spaceship operator to compare objects

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,6 +11,6 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@2.1.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@3.0.0"
     with:
-      php-version: '8.1'
+      php-version: '8.2'

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -15,6 +15,6 @@ on:
 jobs:
   composer-lint:
     name: "Composer Lint"
-    uses: "doctrine/.github/.github/workflows/composer-lint.yml@2.1.0"
+    uses: "doctrine/.github/.github/workflows/composer-lint.yml@3.0.0"
     with:
-      php-version: "8.1"
+      php-version: "8.2"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,6 @@ env:
 jobs:
   phpunit:
     name: "PHPUnit"
-    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@2.1.0"
+    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@3.0.0"
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2"]'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,4 +16,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@3.0.0"
     with:
-      php-versions: '["7.4", "8.0", "8.1", "8.2"]'
+      php-versions: '["8.0", "8.1", "8.2"]'

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@2.1.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@3.0.0"
     with:
       use-next-minor-as-default-branch: true
     secrets:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,6 +11,6 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/static-analysis.yml@2.1.0"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@3.0.0"
     with:
-      php-version: '8.1'
+      php-version: '8.2'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2022 Doctrine Project
+Copyright (c) 2006-2023 Doctrine Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # doctrine-laminas-hydrator
 
-[![Build Status](https://github.com/doctrine/doctrine-laminas-hydrator/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/doctrine-laminas-hydrator/actions/workflows/continuous-integration.yml?query=branch%3A3.2.x)
-[![Code Coverage](https://codecov.io/gh/doctrine/doctrine-laminas-hydrator/branch/3.2.x/graphs/badge.svg)](https://codecov.io/gh/doctrine/doctrine-laminas-hydrator/branch/3.2.x)
+[![Build Status](https://github.com/doctrine/doctrine-laminas-hydrator/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/doctrine-laminas-hydrator/actions/workflows/continuous-integration.yml?query=branch%3A3.3.x)
+[![Code Coverage](https://codecov.io/gh/doctrine/doctrine-laminas-hydrator/branch/3.3.x/graphs/badge.svg)](https://codecov.io/gh/doctrine/doctrine-laminas-hydrator/branch/3.3.x)
 [![Latest Stable Version](https://poser.pugx.org/doctrine/doctrine-laminas-hydrator/v/stable.png)](https://packagist.org/packages/doctrine/doctrine-laminas-hydrator)
 [![Total Downloads](https://poser.pugx.org/doctrine/doctrine-laminas-hydrator/downloads.png)](https://packagist.org/packages/doctrine/doctrine-laminas-hydrator)
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "rss": "https://github.com/doctrine/doctrine-laminas-hydrator/releases.atom"
     },
     "require": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-ctype": "*",
         "doctrine/collections": "^1.6.8",
         "doctrine/inflector": "^2.0.4",

--- a/src/Filter/PropertyName.php
+++ b/src/Filter/PropertyName.php
@@ -18,15 +18,12 @@ final class PropertyName implements FilterInterface
     /** @var string[] */
     private array $properties = [];
 
-    private bool $exclude;
-
     /**
      * @param string|string[] $properties The properties to exclude or include.
      * @param bool            $exclude    If the method should be excluded
      */
-    public function __construct($properties, bool $exclude = true)
+    public function __construct($properties, private bool $exclude = true)
     {
-        $this->exclude    = $exclude;
         $this->properties = is_array($properties)
             ? $properties
             : [$properties];

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -13,7 +13,6 @@ use InvalidArgumentException;
 use LogicException;
 use ReflectionException;
 
-use function get_class;
 use function is_array;
 use function method_exists;
 use function spl_object_hash;
@@ -115,7 +114,7 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
                     'The getter %s to access collection %s in object %s does not exist',
                     $getter,
                     $this->getCollectionName(),
-                    get_class($object)
+                    $object::class
                 )
             );
         }

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -152,6 +152,6 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
      */
     protected function compareObjects(object $a, object $b): int
     {
-        return spl_object_hash($a) <=> spl_object_hash($b);
+        return strcmp(spl_object_hash($a), spl_object_hash($b));
     }
 }

--- a/src/Strategy/AllowRemoveByValue.php
+++ b/src/Strategy/AllowRemoveByValue.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use LogicException;
 
 use function array_udiff;
-use function get_class;
 use function method_exists;
 use function sprintf;
 
@@ -43,7 +42,7 @@ final class AllowRemoveByValue extends AbstractCollectionStrategy
                      entity domain code, but one or both seem to be missing',
                     $adder,
                     $remover,
-                    get_class($object)
+                    $object::class
                 )
             );
         }

--- a/src/Strategy/DisallowRemoveByValue.php
+++ b/src/Strategy/DisallowRemoveByValue.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use LogicException;
 
 use function array_udiff;
-use function get_class;
 use function method_exists;
 use function sprintf;
 
@@ -41,7 +40,7 @@ final class DisallowRemoveByValue extends AbstractCollectionStrategy
                     'DisallowRemove strategy for DoctrineModule hydrator requires %s to
                      be defined in %s entity domain code, but it seems to be missing',
                     $adder,
-                    get_class($object)
+                    $object::class
                 )
             );
         }

--- a/tests/Assets/ByValueDifferentiatorEntity.php
+++ b/tests/Assets/ByValueDifferentiatorEntity.php
@@ -13,18 +13,12 @@ class ByValueDifferentiatorEntity
 
     protected string $field;
 
-    /**
-     * @param string|int $id
-     */
-    public function setId($id): void
+    public function setId(string|int $id): void
     {
         $this->id = $id;
     }
 
-    /**
-     * @return string|int
-     */
-    public function getId()
+    public function getId(): string|int
     {
         return $this->id;
     }

--- a/tests/Assets/DifferentAllowRemoveByValue.php
+++ b/tests/Assets/DifferentAllowRemoveByValue.php
@@ -9,7 +9,6 @@ use Doctrine\Laminas\Hydrator\Strategy\AbstractCollectionStrategy;
 use LogicException;
 
 use function array_udiff;
-use function get_class;
 use function method_exists;
 use function sprintf;
 
@@ -35,7 +34,7 @@ class DifferentAllowRemoveByValue extends AbstractCollectionStrategy
                      entity domain code, but one or both seem to be missing',
                     $adder,
                     $remover,
-                    get_class($object)
+                    $object::class
                 )
             );
         }

--- a/tests/Assets/NamingStrategyEntity.php
+++ b/tests/Assets/NamingStrategyEntity.php
@@ -6,11 +6,8 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class NamingStrategyEntity
 {
-    protected ?string $camelCase = null;
-
-    public function __construct(?string $camelCase = null)
+    public function __construct(protected ?string $camelCase = null)
     {
-        $this->camelCase = $camelCase;
     }
 
     public function setCamelCase(?string $camelCase): void

--- a/tests/Assets/OneToOneEntity.php
+++ b/tests/Assets/OneToOneEntity.php
@@ -10,7 +10,7 @@ class OneToOneEntity
 {
     protected int $id;
 
-    protected ?ByValueDifferentiatorEntity $toOne;
+    protected ?ByValueDifferentiatorEntity $toOne = null;
 
     protected DateTime $createdAt;
 

--- a/tests/Assets/SimpleEntity.php
+++ b/tests/Assets/SimpleEntity.php
@@ -11,18 +11,12 @@ class SimpleEntity
 
     protected string $field;
 
-    /**
-     * @param string|int $id
-     */
-    public function setId($id): void
+    public function setId(string|int $id): void
     {
         $this->id = $id;
     }
 
-    /**
-     * @return string|int
-     */
-    public function getId()
+    public function getId(): string|int
     {
         return $this->id;
     }

--- a/tests/Assets/SimpleEntityReadonlyPhp82.php
+++ b/tests/Assets/SimpleEntityReadonlyPhp82.php
@@ -6,13 +6,7 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 readonly class SimpleEntityReadonlyPhp82
 {
-    protected ?int $id;
-
-    protected ?string $field;
-
-    public function __construct(?int $id, ?string $field)
+    public function __construct(protected ?int $id, protected ?string $field)
     {
-        $this->id    = $id;
-        $this->field = $field;
     }
 }

--- a/tests/Assets/SimpleEntityWithDateTime.php
+++ b/tests/Assets/SimpleEntityWithDateTime.php
@@ -10,7 +10,7 @@ class SimpleEntityWithDateTime
 {
     protected int $id;
 
-    protected ?DateTime $date;
+    protected ?DateTime $date = null;
 
     public function setId(int $id): void
     {

--- a/tests/Assets/SimpleEntityWithGenericField.php
+++ b/tests/Assets/SimpleEntityWithGenericField.php
@@ -21,10 +21,7 @@ class SimpleEntityWithGenericField
         return $this->id;
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function setGenericField($value): void
+    public function setGenericField(mixed $value): void
     {
         $this->genericField = $value;
     }

--- a/tests/Assets/SimpleEntityWithReadonlyPropsPhp81.php
+++ b/tests/Assets/SimpleEntityWithReadonlyPropsPhp81.php
@@ -6,13 +6,10 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class SimpleEntityWithReadonlyPropsPhp81
 {
-    protected readonly ?int $id;
-
     protected ?string $field;
 
-    public function __construct(?int $id)
+    public function __construct(protected readonly ?int $id)
     {
-        $this->id = $id;
     }
 
     public function getId(): int

--- a/tests/Assets/SimplePrivateEntity.php
+++ b/tests/Assets/SimplePrivateEntity.php
@@ -9,12 +9,10 @@ use Exception;
 class SimplePrivateEntity
 {
     /**
-     * @param         mixed $value
-     *
      * @phpcsSuppress SlevomatCodingStandard.Classes.UnusedPrivateElements
      * @phpstan-ignore-next-line
      */
-    private function setPrivate($value): void
+    private function setPrivate(mixed $value): void
     {
         throw new Exception('Should never be called');
     }
@@ -28,10 +26,7 @@ class SimplePrivateEntity
         throw new Exception('Should never be called');
     }
 
-    /**
-     * @param mixed $value
-     */
-    protected function setProtected($value): void
+    protected function setProtected(mixed $value): void
     {
         throw new Exception('Should never be called');
     }

--- a/tests/DoctrineObjectTypeConversionsTest.php
+++ b/tests/DoctrineObjectTypeConversionsTest.php
@@ -196,8 +196,8 @@ class DoctrineObjectTypeConversionsTest extends TestCase
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $now    = new DateTime();
-        $now->setTimestamp(1522353676);
-        $data = ['genericField' => 1522353676];
+        $now->setTimestamp(1_522_353_676);
+        $data = ['genericField' => 1_522_353_676];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
@@ -244,8 +244,8 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->configureObjectManagerForSimpleEntityWithGenericField('datetime_immutable');
 
         $entity = new Assets\SimpleEntityWithGenericField();
-        $now    = (new DateTimeImmutable())->setTimestamp(1522353676);
-        $data   = ['genericField' => 1522353676];
+        $now    = (new DateTimeImmutable())->setTimestamp(1_522_353_676);
+        $data   = ['genericField' => 1_522_353_676];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
@@ -293,8 +293,8 @@ class DoctrineObjectTypeConversionsTest extends TestCase
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $now    = new DateTime();
-        $now->setTimestamp(1522353676);
-        $data = ['genericField' => 1522353676];
+        $now->setTimestamp(1_522_353_676);
+        $data = ['genericField' => 1_522_353_676];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
@@ -341,8 +341,8 @@ class DoctrineObjectTypeConversionsTest extends TestCase
         $this->configureObjectManagerForSimpleEntityWithGenericField('datetimetz_immutable');
 
         $entity = new Assets\SimpleEntityWithGenericField();
-        $now    = (new DateTimeImmutable())->setTimestamp(1522353676);
-        $data   = ['genericField' => 1522353676];
+        $now    = (new DateTimeImmutable())->setTimestamp(1_522_353_676);
+        $data   = ['genericField' => 1_522_353_676];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
@@ -390,8 +390,8 @@ class DoctrineObjectTypeConversionsTest extends TestCase
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $now    = new DateTime();
-        $now->setTimestamp(1522353676);
-        $data = ['genericField' => 1522353676];
+        $now->setTimestamp(1_522_353_676);
+        $data = ['genericField' => 1_522_353_676];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 
@@ -439,8 +439,8 @@ class DoctrineObjectTypeConversionsTest extends TestCase
 
         $entity = new Assets\SimpleEntityWithGenericField();
         $now    = new DateTime();
-        $now->setTimestamp(1522353676);
-        $data = ['genericField' => 1522353676];
+        $now->setTimestamp(1_522_353_676);
+        $data = ['genericField' => 1_522_353_676];
 
         $entity = $this->hydratorByValue->hydrate($data, $entity);
 


### PR DESCRIPTION
Use strcmp instead of spaceship operator to prevent some weird behaviour when comparing hashes with more than 16 characters, see issue #71 .