### PR TITLE
Allow PHP 8.3

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -13,4 +13,4 @@ jobs:
     name: "Coding Standards"
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@3.0.0"
     with:
-      php-version: '8.2'
+      php-version: '8.3'

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -17,4 +17,4 @@ jobs:
     name: "Composer Lint"
     uses: "doctrine/.github/.github/workflows/composer-lint.yml@3.0.0"
     with:
-      php-version: "8.2"
+      php-version: "8.3"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,4 +16,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@3.0.0"
     with:
-      php-versions: '["8.0", "8.1", "8.2"]'
+      php-versions: '["8.0", "8.1", "8.2", "8.3"]'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,4 +13,4 @@ jobs:
     name: "Static Analysis"
     uses: "doctrine/.github/.github/workflows/static-analysis.yml@3.0.0"
     with:
-      php-version: '8.2'
+      php-version: '8.3'

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         "rss": "https://github.com/doctrine/doctrine-laminas-hydrator/releases.atom"
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-ctype": "*",
         "doctrine/collections": "^1.8.0 || ^2.0.0",
         "doctrine/inflector": "^2.0.4",
-        "doctrine/persistence": "^2.2.3 || ^3.0.0",
-        "laminas/laminas-hydrator": "^4.3.1",
-        "laminas/laminas-stdlib": "^3.6.1"
+        "doctrine/persistence": "^2.5.0 || ^3.0.0",
+        "laminas/laminas-hydrator": "^4.13.0",
+        "laminas/laminas-stdlib": "^3.14.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^11.1.0",


### PR DESCRIPTION
This PR adds support for PHP 8.3. Fortunately, all dependencies of this library are already PHP 8.3-compatible, so this step is pretty straight forward.

Minimum constraints for doctrine/collections has been raised to ensure that BC-layer is always present in 2.x  series. Minimum constraint for laminas-hydrator and laminas-stdlib has been raised to lowest versions supporting PHP 8.0, so that change is only of cosmetic nature (but makes maintenance easier and, hence, should be made).