### PR TITLE
Updated doctrine-coding-standard

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -13,4 +13,4 @@ jobs:
     name: "Coding Standards"
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@3.0.0"
     with:
-      php-version: '8.2'
+      php-version: '8.3'

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -17,4 +17,4 @@ jobs:
     name: "Composer Lint"
     uses: "doctrine/.github/.github/workflows/composer-lint.yml@3.0.0"
     with:
-      php-version: "8.2"
+      php-version: "8.3"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,4 +16,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@3.0.0"
     with:
-      php-versions: '["8.0", "8.1", "8.2"]'
+      php-versions: '["8.0", "8.1", "8.2", "8.3"]'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,4 +13,4 @@ jobs:
     name: "Static Analysis"
     uses: "doctrine/.github/.github/workflows/static-analysis.yml@3.0.0"
     with:
-      php-version: '8.2'
+      php-version: '8.3'

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         "rss": "https://github.com/doctrine/doctrine-laminas-hydrator/releases.atom"
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-ctype": "*",
         "doctrine/collections": "^1.8.0 || ^2.0.0",
         "doctrine/inflector": "^2.0.4",
-        "doctrine/persistence": "^2.2.3 || ^3.0.0",
-        "laminas/laminas-hydrator": "^4.3.1",
-        "laminas/laminas-stdlib": "^3.6.1"
+        "doctrine/persistence": "^2.5.0 || ^3.0.0",
+        "laminas/laminas-hydrator": "^4.13.0",
+        "laminas/laminas-stdlib": "^3.14.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^11.1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "laminas/laminas-stdlib": "^3.14.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^11.1.0",
+        "doctrine/coding-standard": "^12.0.0",
         "phpstan/phpstan": "^1.9.2",
         "phpunit/phpunit": "^9.5.26",
         "vimeo/psalm": "^4.30"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,8 @@
     <arg name="cache" value=".phpcs.cache"/>
     <arg name="colors"/>
 
-    <!-- set minimal required PHP version (7.4) -->
-    <config name="php_version" value="70400"/>
+    <!-- set minimal required PHP version (8.0) -->
+    <config name="php_version" value="80000"/>
 
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>
@@ -21,5 +21,9 @@
         <!-- Not used for consistency with the Laminas project -->
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
+        <!-- Not used until next major release to prevent BC breaks -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
     </rule>
 </ruleset>

--- a/src/DoctrineObject.php
+++ b/src/DoctrineObject.php
@@ -49,7 +49,7 @@ use function substr;
 
 class DoctrineObject extends AbstractHydrator
 {
-    protected ?ClassMetadata $metadata = null;
+    protected ClassMetadata|null $metadata = null;
 
     /** @var class-string<Strategy\CollectionStrategyInterface> */
     protected string $defaultByValueStrategy = AllowRemoveByValue::class;
@@ -63,7 +63,7 @@ class DoctrineObject extends AbstractHydrator
      * @param ObjectManager $objectManager The ObjectManager to use
      * @param bool          $byValue       If set to true, hydrator will always use entity's public API
      */
-    public function __construct(protected ObjectManager $objectManager, protected bool $byValue = true, ?Inflector $inflector = null)
+    public function __construct(protected ObjectManager $objectManager, protected bool $byValue = true, Inflector|null $inflector = null)
     {
         $this->inflector = $inflector ?? InflectorFactory::create()->build();
     }
@@ -306,7 +306,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @return mixed|null
      */
-    public function hydrateValue(string $name, $value, ?array $data = null)
+    public function hydrateValue(string $name, $value, array|null $data = null)
     {
         $value = parent::hydrateValue($name, $value, $data);
 
@@ -337,7 +337,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @template T of object
      */
-    protected function hydrateByValue(array $data, ?object $object): object
+    protected function hydrateByValue(array $data, object|null $object): object
     {
         $tryObject = $this->tryConvertArrayToObject($data, $object);
         $metadata  = $this->getClassMetadata();
@@ -400,7 +400,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @template T of object
      */
-    protected function hydrateByReference(array $data, ?object $object): object
+    protected function hydrateByReference(array $data, object|null $object): object
     {
         $tryObject = $this->tryConvertArrayToObject($data, $object);
         $metadata  = $this->getClassMetadata();
@@ -465,7 +465,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @template T of object
      */
-    protected function tryConvertArrayToObject(array $data, object $object): ?object
+    protected function tryConvertArrayToObject(array $data, object $object): object|null
     {
         $metadata         = $this->getClassMetadata();
         $identifierNames  = $metadata->getIdentifierFieldNames();
@@ -498,7 +498,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @param  class-string $target
      */
-    protected function toOne(string $target, mixed $value): ?object
+    protected function toOne(string $target, mixed $value): object|null
     {
         $metadata = $this->objectManager->getClassMetadata($target);
 
@@ -612,7 +612,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @return mixed|null
      */
-    protected function handleTypeConversions(mixed $value, ?string $typeOfField)
+    protected function handleTypeConversions(mixed $value, string|null $typeOfField)
     {
         if ($value === null) {
             return null;
@@ -698,7 +698,7 @@ class DoctrineObject extends AbstractHydrator
      *
      * @template T of object
      */
-    protected function find(mixed $identifiers, string $targetClass): ?object
+    protected function find(mixed $identifiers, string $targetClass): object|null
     {
         if ($identifiers instanceof $targetClass) {
             return $identifiers;

--- a/src/Filter/PropertyName.php
+++ b/src/Filter/PropertyName.php
@@ -29,7 +29,7 @@ final class PropertyName implements FilterInterface
             : [$properties];
     }
 
-    public function filter(string $property, ?object $instance = null): bool
+    public function filter(string $property, object|null $instance = null): bool
     {
         return in_array($property, $this->properties, true)
             ? ! $this->exclude

--- a/src/Strategy/AbstractCollectionStrategy.php
+++ b/src/Strategy/AbstractCollectionStrategy.php
@@ -22,15 +22,15 @@ use function strcmp;
 /** @internal */
 abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
 {
-    private ?string $collectionName = null;
+    private string|null $collectionName = null;
 
-    private ?ClassMetadata $metadata = null;
+    private ClassMetadata|null $metadata = null;
 
-    private ?object $object = null;
+    private object|null $object = null;
 
     private Inflector $inflector;
 
-    public function __construct(?Inflector $inflector = null)
+    public function __construct(Inflector|null $inflector = null)
     {
         $this->inflector = $inflector ?? InflectorFactory::create()->build();
     }
@@ -85,7 +85,7 @@ abstract class AbstractCollectionStrategy implements CollectionStrategyInterface
      *
      * @return mixed       Returns the value that should be extracted.
      */
-    public function extract($value, ?object $object = null)
+    public function extract($value, object|null $object = null)
     {
         return $value;
     }

--- a/src/Strategy/AllowRemoveByReference.php
+++ b/src/Strategy/AllowRemoveByReference.php
@@ -23,7 +23,7 @@ final class AllowRemoveByReference extends AbstractCollectionStrategy
      *
      * @return mixed Returns the value that should be hydrated.
      */
-    public function hydrate($value, ?array $data)
+    public function hydrate($value, array|null $data)
     {
         $collection      = $this->getCollectionFromObjectByReference();
         $collectionArray = $collection->toArray();

--- a/src/Strategy/AllowRemoveByValue.php
+++ b/src/Strategy/AllowRemoveByValue.php
@@ -28,7 +28,7 @@ final class AllowRemoveByValue extends AbstractCollectionStrategy
      *
      * @return mixed Returns the value that should be hydrated.
      */
-    public function hydrate($value, ?array $data)
+    public function hydrate($value, array|null $data)
     {
         // AllowRemove strategy need "adder" and "remover"
         $adder   = 'add' . $this->getInflector()->classify($this->getCollectionName());

--- a/src/Strategy/DisallowRemoveByReference.php
+++ b/src/Strategy/DisallowRemoveByReference.php
@@ -23,7 +23,7 @@ final class DisallowRemoveByReference extends AbstractCollectionStrategy
      *
      * @return mixed Returns the value that should be hydrated.
      */
-    public function hydrate($value, ?array $data)
+    public function hydrate($value, array|null $data)
     {
         $collection      = $this->getCollectionFromObjectByReference();
         $collectionArray = $collection->toArray();

--- a/src/Strategy/DisallowRemoveByValue.php
+++ b/src/Strategy/DisallowRemoveByValue.php
@@ -28,7 +28,7 @@ final class DisallowRemoveByValue extends AbstractCollectionStrategy
      *
      * @return mixed Returns the value that should be hydrated.
      */
-    public function hydrate($value, ?array $data)
+    public function hydrate($value, array|null $data)
     {
         // AllowRemove strategy need "adder"
         $adder  = 'add' . $this->getInflector()->classify($this->getCollectionName());

--- a/tests/Assets/ContextStrategy.php
+++ b/tests/Assets/ContextStrategy.php
@@ -13,7 +13,7 @@ class ContextStrategy implements StrategyInterface
      *
      * @return mixed
      */
-    public function extract($value, ?object $object = null)
+    public function extract($value, object|null $object = null)
     {
         return (string) $value . $object->getField();
     }
@@ -24,7 +24,7 @@ class ContextStrategy implements StrategyInterface
      *
      * @return mixed
      */
-    public function hydrate($value, ?array $data = null)
+    public function hydrate($value, array|null $data = null)
     {
         return $value . $data['field'];
     }

--- a/tests/Assets/DifferentAllowRemoveByReference.php
+++ b/tests/Assets/DifferentAllowRemoveByReference.php
@@ -20,7 +20,7 @@ class DifferentAllowRemoveByReference extends AbstractCollectionStrategy
      *
      * @throws ReflectionException
      */
-    public function hydrate($value, ?array $data): Collection
+    public function hydrate($value, array|null $data): Collection
     {
         $collection      = $this->getCollectionFromObjectByReference();
         $collectionArray = $collection->toArray();

--- a/tests/Assets/DifferentAllowRemoveByValue.php
+++ b/tests/Assets/DifferentAllowRemoveByValue.php
@@ -20,7 +20,7 @@ class DifferentAllowRemoveByValue extends AbstractCollectionStrategy
      *
      * @return array|mixed|mixed[]
      */
-    public function hydrate($value, ?array $data)
+    public function hydrate($value, array|null $data)
     {
         // AllowRemove strategy need "adder" and "remover"
         $adder   = 'add' . $this->getInflector()->classify($this->getCollectionName());

--- a/tests/Assets/NamingStrategyEntity.php
+++ b/tests/Assets/NamingStrategyEntity.php
@@ -6,16 +6,16 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class NamingStrategyEntity
 {
-    public function __construct(protected ?string $camelCase = null)
+    public function __construct(protected string|null $camelCase = null)
     {
     }
 
-    public function setCamelCase(?string $camelCase): void
+    public function setCamelCase(string|null $camelCase): void
     {
         $this->camelCase = $camelCase;
     }
 
-    public function getCamelCase(): ?string
+    public function getCamelCase(): string|null
     {
         return $this->camelCase;
     }

--- a/tests/Assets/OneToManyEntityWithEntities.php
+++ b/tests/Assets/OneToManyEntityWithEntities.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 
 class OneToManyEntityWithEntities extends OneToManyEntity
 {
-    public function __construct(?ArrayCollection $entities = null)
+    public function __construct(ArrayCollection|null $entities = null)
     {
         $this->entities = $entities;
     }

--- a/tests/Assets/OneToOneEntity.php
+++ b/tests/Assets/OneToOneEntity.php
@@ -10,7 +10,7 @@ class OneToOneEntity
 {
     protected int $id;
 
-    protected ?ByValueDifferentiatorEntity $toOne = null;
+    protected ByValueDifferentiatorEntity|null $toOne = null;
 
     protected DateTime $createdAt;
 
@@ -24,7 +24,7 @@ class OneToOneEntity
         return $this->id;
     }
 
-    public function setToOne(?ByValueDifferentiatorEntity $entity = null, bool $modifyValue = true): void
+    public function setToOne(ByValueDifferentiatorEntity|null $entity = null, bool $modifyValue = true): void
     {
         // Modify the value to illustrate the difference between by value and by reference
         if ($modifyValue && $entity !== null) {
@@ -34,7 +34,7 @@ class OneToOneEntity
         $this->toOne = $entity;
     }
 
-    public function getToOne(bool $modifyValue = true): ?ByValueDifferentiatorEntity
+    public function getToOne(bool $modifyValue = true): ByValueDifferentiatorEntity|null
     {
         // Make some modifications to the association so that we can demonstrate difference between
         // by value and by reference

--- a/tests/Assets/OneToOneEntityNotNullable.php
+++ b/tests/Assets/OneToOneEntityNotNullable.php
@@ -30,7 +30,7 @@ class OneToOneEntityNotNullable
         $this->toOne = $entity;
     }
 
-    public function getToOne(bool $modifyValue = true): ?ByValueDifferentiatorEntity
+    public function getToOne(bool $modifyValue = true): ByValueDifferentiatorEntity|null
     {
         // Make some modifications to the association so that we can demonstrate difference between
         // by value and by reference

--- a/tests/Assets/SimpleEntityPhp74.php
+++ b/tests/Assets/SimpleEntityPhp74.php
@@ -6,9 +6,9 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class SimpleEntityPhp74
 {
-    protected ?int $id;
+    protected int|null $id;
 
-    protected ?string $field;
+    protected string|null $field;
 
     public function setId(int $id): void
     {

--- a/tests/Assets/SimpleEntityReadonlyPhp82.php
+++ b/tests/Assets/SimpleEntityReadonlyPhp82.php
@@ -6,7 +6,7 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 readonly class SimpleEntityReadonlyPhp82
 {
-    public function __construct(protected ?int $id, protected ?string $field)
+    public function __construct(protected int|null $id, protected string|null $field)
     {
     }
 }

--- a/tests/Assets/SimpleEntityWithDateTime.php
+++ b/tests/Assets/SimpleEntityWithDateTime.php
@@ -10,7 +10,7 @@ class SimpleEntityWithDateTime
 {
     protected int $id;
 
-    protected ?DateTime $date = null;
+    protected DateTime|null $date = null;
 
     public function setId(int $id): void
     {
@@ -22,12 +22,12 @@ class SimpleEntityWithDateTime
         return $this->id;
     }
 
-    public function setDate(?DateTime $date = null): void
+    public function setDate(DateTime|null $date = null): void
     {
         $this->date = $date;
     }
 
-    public function getDate(): ?DateTime
+    public function getDate(): DateTime|null
     {
         return $this->date;
     }

--- a/tests/Assets/SimpleEntityWithEnumPhp81.php
+++ b/tests/Assets/SimpleEntityWithEnumPhp81.php
@@ -8,7 +8,7 @@ class SimpleEntityWithEnumPhp81
 {
     protected int $id;
 
-    protected ?SimpleEnumPhp81 $enum = null;
+    protected SimpleEnumPhp81|null $enum = null;
 
     public function setId(int $id): void
     {
@@ -20,12 +20,12 @@ class SimpleEntityWithEnumPhp81
         return $this->id;
     }
 
-    public function setEnum(?SimpleEnumPhp81 $enum = null): void
+    public function setEnum(SimpleEnumPhp81|null $enum = null): void
     {
         $this->enum = $enum;
     }
 
-    public function getEnum(): ?SimpleEnumPhp81
+    public function getEnum(): SimpleEnumPhp81|null
     {
         return $this->enum;
     }

--- a/tests/Assets/SimpleEntityWithGenericField.php
+++ b/tests/Assets/SimpleEntityWithGenericField.php
@@ -6,7 +6,7 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class SimpleEntityWithGenericField
 {
-    protected ?int $id = null;
+    protected int|null $id = null;
 
     /** @var mixed */
     protected $genericField;
@@ -16,7 +16,7 @@ class SimpleEntityWithGenericField
         $this->id = $id;
     }
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }

--- a/tests/Assets/SimpleEntityWithReadonlyPropsPhp81.php
+++ b/tests/Assets/SimpleEntityWithReadonlyPropsPhp81.php
@@ -6,9 +6,9 @@ namespace DoctrineTest\Laminas\Hydrator\Assets;
 
 class SimpleEntityWithReadonlyPropsPhp81
 {
-    protected ?string $field;
+    protected string|null $field;
 
-    public function __construct(protected readonly ?int $id)
+    public function __construct(protected readonly int|null $id)
     {
     }
 

--- a/tests/Assets/SimpleEnumStrategyPhp81.php
+++ b/tests/Assets/SimpleEnumStrategyPhp81.php
@@ -9,7 +9,7 @@ use Laminas\Hydrator\Strategy\StrategyInterface;
 class SimpleEnumStrategyPhp81 implements StrategyInterface
 {
     /** @param mixed $value */
-    public function extract($value, ?object $object = null): ?int
+    public function extract($value, object|null $object = null): int|null
     {
         if ($value === null) {
             return null;
@@ -22,7 +22,7 @@ class SimpleEnumStrategyPhp81 implements StrategyInterface
      * @param mixed                        $value
      * @param array<array-key, mixed>|null $data
      */
-    public function hydrate($value, ?array $data): ?SimpleEnumPhp81
+    public function hydrate($value, array|null $data): SimpleEnumPhp81|null
     {
         if ($value === null) {
             return null;

--- a/tests/Assets/SimpleStrategy.php
+++ b/tests/Assets/SimpleStrategy.php
@@ -13,7 +13,7 @@ class SimpleStrategy implements StrategyInterface
      *
      * @return mixed
      */
-    public function extract($value, ?object $object = null)
+    public function extract($value, object|null $object = null)
     {
         return 'modified while extracting';
     }
@@ -24,7 +24,7 @@ class SimpleStrategy implements StrategyInterface
      *
      * @return mixed
      */
-    public function hydrate($value, ?array $data)
+    public function hydrate($value, array|null $data)
     {
         return 'modified while hydrating';
     }

--- a/tests/DoctrineObjectTest.php
+++ b/tests/DoctrineObjectTest.php
@@ -424,7 +424,7 @@ class DoctrineObjectTest extends TestCase
                 $this->equalTo('embedded'),
             ))
             ->willReturnCallback(
-                static function (string $arg): ?string {
+                static function (string $arg): string|null {
                     if ($arg === 'id') {
                         return 'integer';
                     }
@@ -2769,7 +2769,7 @@ class DoctrineObjectTest extends TestCase
              *
              * @return string[]
              */
-            public function extract($value, ?object $object = null): array
+            public function extract($value, object|null $object = null): array
             {
                 return explode(',', $value);
             }
@@ -2778,7 +2778,7 @@ class DoctrineObjectTest extends TestCase
              * @param mixed    $value
              * @param string[] $data
              */
-            public function hydrate($value, ?array $data): string
+            public function hydrate($value, array|null $data): string
             {
                 return implode(',', $value);
             }
@@ -2801,7 +2801,7 @@ class DoctrineObjectTest extends TestCase
              *
              * @return string[]
              */
-            public function extract($value, ?object $object = null): array
+            public function extract($value, object|null $object = null): array
             {
                 return explode(',', $value);
             }
@@ -2810,7 +2810,7 @@ class DoctrineObjectTest extends TestCase
              * @param mixed    $value
              * @param string[] $data
              */
-            public function hydrate($value, ?array $data): string
+            public function hydrate($value, array|null $data): string
             {
                 return implode(',', $value);
             }

--- a/tests/DoctrineObjectTypeConversionsTest.php
+++ b/tests/DoctrineObjectTypeConversionsTest.php
@@ -43,7 +43,7 @@ class DoctrineObjectTypeConversionsTest extends TestCase
             ->will($this->returnValue($this->metadata));
     }
 
-    public function configureObjectManagerForSimpleEntityWithGenericField(?string $genericFieldType): void
+    public function configureObjectManagerForSimpleEntityWithGenericField(string|null $genericFieldType): void
     {
         $refl = new ReflectionClass(Assets\SimpleEntityWithGenericField::class);
 


### PR DESCRIPTION
*Note:* This PR is based on #81, which needs to be reviewed an merged first.

This PR upgrades doctrine-coding-standard from v11 to v12 and applies the minimum PHP version 8.0 to phpcs. It looks like a lot of changes, but most came trough `SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.DisallowedShortNullable` which changes thinks like `?array` to `array|null`. This change is not a BC break and, hence, can go into the next minor release.