### PR TITLE
Drop PHP 8.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,4 +16,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@3.0.0"
     with:
-      php-versions: '["8.0", "8.1", "8.2", "8.3"]'
+      php-versions: '["8.1", "8.2", "8.3"]'

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "rss": "https://github.com/doctrine/doctrine-laminas-hydrator/releases.atom"
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-ctype": "*",
         "doctrine/collections": "^1.8.0 || ^2.0.0",
         "doctrine/inflector": "^2.0.4",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,8 +6,8 @@
     <arg name="cache" value=".phpcs.cache"/>
     <arg name="colors"/>
 
-    <!-- set minimal required PHP version (8.0) -->
-    <config name="php_version" value="80000"/>
+    <!-- set minimal required PHP version (8.1) -->
+    <config name="php_version" value="80100"/>
 
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>


### PR DESCRIPTION
This PR removes support for PHP 8.0 as it is EOL for over one year now.