### PR TITLE
Drop support for doctrine/collections 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-ctype": "*",
-        "doctrine/collections": "^1.8.0 || ^2.0.0",
+        "doctrine/collections": "^2.0.0",
         "doctrine/inflector": "^2.0.4",
         "doctrine/persistence": "^2.5.0 || ^3.0.0",
         "laminas/laminas-hydrator": "^4.13.0",


### PR DESCRIPTION
With this PR, doctrine/collections 2.x is required and 1.x is not supported anymore.